### PR TITLE
docs: /NS AUTHRESET helpfiles in 4 languages (us/it/fr/es)

### DIFF
--- a/run/data/helpfiles/es/nickserv/authreset
+++ b/run/data/helpfiles/es/nickserv/authreset
@@ -1,0 +1,51 @@
+*** NickServ Help - Comando: AUTHRESET ***
+Anula las autorizaciones pendientes sobre un nick.
+
+Este comando está reservado a los services operators y
+a los helpers. Cancela un procedimiento en curso que
+espera que el propietario del nick actúe sobre un E-Mail
+enviado por los servicios (código AUTH de registro,
+cambio de E-Mail, drop o reset de contraseña).
+
+Según el sub-comando opcional, el comando actúa sobre un
+subconjunto distinto del estado del nick.
+
+Sintaxis:
+
+/ns AUTHRESET nickname [MAILCHANGE | DROP | RESETPASS]
+
+Sin sub-comando, la acción es un reset COMPLETO: el nick
+vuelve al estado no autorizado (se pone el flag NI_AUTH),
+tanto la E-Mail registrada como la pendiente se eliminan,
+y los posibles estados MailChange y Drop se limpian. El
+propietario deberá hacer AUTH de nuevo con el código que
+los servicios emitirán en el siguiente identify.
+
+Atención: ejecutar AUTHRESET sin sub-comando sobre un
+nick que sólo tiene un reset de contraseña pendiente
+(flag NI_PASSRESET) casi nunca es lo que quieres. Elimina
+la E-Mail registrada sin limpiar NI_PASSRESET, dejando
+al propietario bloqueado hasta que se ejecute
+AUTHRESET nickname RESETPASS. En este caso utiliza
+directamente AUTHRESET nickname RESETPASS.
+
+Sub-comandos:
+
+MAILCHANGE  Anula un cambio de E-Mail pendiente. Limpia
+            NI_MAILCHANGE y NI_NOMAIL, elimina la E-Mail
+            pendiente y el código AUTH. La E-Mail
+            registrada y la contraseña no se tocan.
+
+DROP        Anula un drop de nick pendiente. Limpia
+            NI_DROP y elimina el código AUTH. La E-Mail
+            registrada y la contraseña no se tocan.
+
+RESETPASS   Anula un reset de contraseña pendiente (ver
+            SENDPASS y RESETPASS). Limpia NI_PASSRESET y
+            elimina el código AUTH. La E-Mail registrada
+            y la contraseña no se tocan.
+
+Todas las operaciones se anuncian vía GlobOps y se loguean.
+
+Para mas informaciòn, digita /join #IRCHelp
+*** Fin del Help ***

--- a/run/data/helpfiles/fr/nickserv/authreset
+++ b/run/data/helpfiles/fr/nickserv/authreset
@@ -1,0 +1,55 @@
+*** NickServ Help - Commande: AUTHRESET ***
+Annule les autorisations en cours sur un nick.
+
+Cette commande est réservée aux services operators et aux
+helpers. Elle annule une procédure en cours qui attend
+que le propriétaire du nick agisse sur un E-Mail envoyé
+par les services (code AUTH d'enregistrement, changement
+d'E-Mail, drop ou réinitialisation de mot de passe).
+
+Selon la sous-commande optionnelle, la commande agit sur
+un sous-ensemble différent de l'état du nick.
+
+Syntaxe :
+
+/ns AUTHRESET nickname [MAILCHANGE | DROP | RESETPASS]
+
+Sans sous-commande, l'action est une réinitialisation
+COMPLÈTE : le nick est remis à l'état non autorisé (le
+flag NI_AUTH est posé), l'E-Mail enregistrée et celle en
+attente sont supprimées, les éventuels états MailChange
+et Drop sont nettoyés. Le propriétaire devra refaire AUTH
+avec le code que les services émettront à la prochaine
+identification.
+
+Attention : exécuter AUTHRESET sans sous-commande sur un
+nick qui n'a qu'une réinitialisation de mot de passe en
+attente (flag NI_PASSRESET) est presque toujours une
+erreur. Cela supprime l'E-Mail enregistrée sans nettoyer
+NI_PASSRESET, laissant le propriétaire bloqué tant que
+AUTHRESET nickname RESETPASS n'est pas exécuté. Dans ce
+cas utilise directement AUTHRESET nickname RESETPASS.
+
+Sous-commandes :
+
+MAILCHANGE  Annule un changement d'E-Mail en cours.
+            Nettoie NI_MAILCHANGE et NI_NOMAIL, supprime
+            l'E-Mail en attente et le code AUTH. L'E-Mail
+            enregistrée et le mot de passe ne sont pas
+            touchés.
+
+DROP        Annule un drop de nick en cours. Nettoie
+            NI_DROP et supprime le code AUTH. L'E-Mail
+            enregistrée et le mot de passe ne sont pas
+            touchés.
+
+RESETPASS   Annule une réinitialisation de mot de passe
+            en cours (voir SENDPASS et RESETPASS). Nettoie
+            NI_PASSRESET et supprime le code AUTH.
+            L'E-Mail enregistrée et le mot de passe ne
+            sont pas touchés.
+
+Toutes les opérations sont annoncées via GlobOps et loggées.
+
+Pour tout renseignement, tape /join #IRCHelp
+*** Fin de l'Help ***

--- a/run/data/helpfiles/it/nickserv/authreset
+++ b/run/data/helpfiles/it/nickserv/authreset
@@ -1,0 +1,52 @@
+*** NickServ Help - Comando: AUTHRESET ***
+Annulla le autorizzazioni in corso su un nick.
+
+Questo comando e' riservato agli services operator e agli
+helper. Cancella una procedura in corso che attende che
+il proprietario del nick agisca su una E-Mail inviata dai
+servizi (codice AUTH per la registrazione, il cambio di
+E-Mail, il drop o il reset della password).
+
+A seconda del sotto-comando opzionale, il comando agisce
+su una porzione diversa dello stato del nick.
+
+Sintassi:
+
+/ns AUTHRESET nickname [MAILCHANGE | DROP | RESETPASS]
+
+Senza sotto-comando, l'azione e' un reset COMPLETO: il
+nick viene riportato allo stato non autorizzato (flag
+NI_AUTH attivo), sia la E-Mail registrata che quella in
+pending vengono rimosse, eventuali stati di MailChange
+e Drop vengono annullati. Il proprietario dovra' fare
+di nuovo AUTH con il codice che i servizi emetteranno
+al prossimo identify.
+
+Attenzione: eseguire AUTHRESET senza sotto-comando su un
+nick che ha solo un reset password pendente (flag
+NI_PASSRESET) quasi mai e' cio' che vuoi. Rimuove la
+E-Mail registrata senza pulire NI_PASSRESET, lasciando
+il proprietario bloccato finche' non viene eseguito
+AUTHRESET nickname RESETPASS. In questo caso usa
+direttamente AUTHRESET nickname RESETPASS.
+
+Sotto-comandi:
+
+MAILCHANGE  Annulla un cambio di E-Mail in corso. Pulisce
+            NI_MAILCHANGE e NI_NOMAIL, rimuove la E-Mail
+            in pending e il codice AUTH. L'E-Mail
+            registrata e la password non vengono toccate.
+
+DROP        Annulla un drop del nick in corso. Pulisce
+            NI_DROP e rimuove il codice AUTH. L'E-Mail
+            registrata e la password non vengono toccate.
+
+RESETPASS   Annulla un reset password in corso (vedi
+            SENDPASS e RESETPASS). Pulisce NI_PASSRESET
+            e rimuove il codice AUTH. L'E-Mail registrata
+            e la password non vengono toccate.
+
+Tutte le operazioni sono annunciate via GlobOps e loggate.
+
+Per ulteriori chiarimenti, digita /join #IRCHelp
+*** Fine dell'Help ***

--- a/run/data/helpfiles/us/nickserv/authreset
+++ b/run/data/helpfiles/us/nickserv/authreset
@@ -1,0 +1,49 @@
+*** NickServ Help - Command: AUTHRESET ***
+Resets pending authorizations on a nickname.
+
+This command is reserved to services operators and helpers.
+It cancels a pending procedure that expects the nick owner
+to act on an E-Mail sent by services (AUTH code for
+registration, mail change, drop, or password reset).
+
+Depending on the optional sub-command, the command operates
+on a different subset of the nickname's state.
+
+Syntax:
+
+/ns AUTHRESET nickname [MAILCHANGE | DROP | RESETPASS]
+
+Without a sub-command, the command performs a FULL reset:
+the nickname is moved back to unauthorized state (flag
+NI_AUTH is set), both the registered and the pending
+E-Mail are removed, and pending MailChange / Drop state
+is cleared. The owner will have to AUTH again with the
+new code that services will request on next identify.
+
+Warning: running AUTHRESET with no sub-command on a nick
+that only has a pending password reset (flag NI_PASSRESET)
+is almost never what you want. It wipes the registered
+E-Mail without clearing NI_PASSRESET, locking the owner
+out until AUTHRESET nickname RESETPASS is run. In that
+case, use AUTHRESET nickname RESETPASS directly.
+
+Sub-commands:
+
+MAILCHANGE  Cancel a pending change of E-Mail. Clears
+            NI_MAILCHANGE and NI_NOMAIL, drops the pending
+            E-Mail and the AUTH code. The registered
+            E-Mail and the password are left untouched.
+
+DROP        Cancel a pending nickname drop. Clears NI_DROP
+            and drops the AUTH code. The registered E-Mail
+            and the password are left untouched.
+
+RESETPASS   Cancel a pending password reset (see SENDPASS
+            and RESETPASS). Clears NI_PASSRESET and drops
+            the AUTH code. The registered E-Mail and the
+            password are left untouched.
+
+All operations are announced via GlobOps and logged.
+
+Type /join #IRCHelp for more information.
+*** End of Help ***


### PR DESCRIPTION
## Summary

Add `/NS AUTHRESET` helpfiles for us / it / fr / es. Follow-up to #5.

AUTHRESET has historically been oper-only (`ULEVEL_HOP`) and undocumented via `/ns HELP`, so the exact semantics of the bare form vs. the `MAILCHANGE` / `DROP` / `RESETPASS` sub-commands lived only in the source. #5 added the `RESETPASS` sub-command and surfaced a footgun that bit an oper during live validation today: running bare `AUTHRESET` on a nick that only has a pending password reset (`NI_PASSRESET`) wipes the registered e-mail without clearing `NI_PASSRESET`, locking the owner out until `AUTHRESET nickname RESETPASS` is run.

Each new helpfile:

- enumerates every path `do_authreset` takes (bare / `MAILCHANGE` / `DROP` / `RESETPASS`) with the exact flag set each one clears;
- warns loudly against bare `AUTHRESET` on `NI_PASSRESET`-only nicks and directs to `AUTHRESET nickname RESETPASS` instead;
- notes that every path is announced via GlobOps and logged.

Tone and structure mirror the `resetpass` helpfiles from #5. The user-facing NickServ `index` is **not** touched — AUTHRESET is oper-only, so `/ns HELP AUTHRESET` discovery is enough.

## Test plan

- [ ] `/ns HELP AUTHRESET` on each lang returns the new text (no services restart needed, helpfiles are read from disk on each HELP)
- [ ] No source changes → no build / behaviour regression