### PR TITLE
ci: Dockerfile + GitHub Actions build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: build
+
+on:
+  push:
+    branches: [master, develop, 'features/**', 'feat/**', 'ci/**']
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  build:
+    name: build (${{ matrix.container }})
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - debian:trixie
+          - debian:bookworm
+          - ubuntu:24.04
+
+    steps:
+      - name: install build deps
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential libc6-dev ca-certificates git
+
+      - uses: actions/checkout@v4
+
+      - name: configure
+        run: ./configure
+
+      - name: build
+        run: make
+
+      - name: verify binary
+        run: |
+          test -x ./src/services
+          ls -la ./src/services
+
+      - uses: actions/upload-artifact@v4
+        if: matrix.container == 'debian:trixie'
+        with:
+          name: services-binary
+          path: src/services
+          retention-days: 7
+
+  docker:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build image
+        run: docker build -t azzurra-services:ci .
+      - name: smoke-check binary inside image
+        run: |
+          docker run --rm --entrypoint sh azzurra-services:ci \
+            -c 'test -x /build/src/services'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,12 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            build-essential libc6-dev ca-certificates git
+            build-essential libc6-dev ca-certificates git python3
 
       - uses: actions/checkout@v4
+
+      - name: compile language files
+        run: python3 lang/langcomp.py
 
       - name: configure
         run: ./configure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:trixie
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libc6-dev \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY . .
+
+RUN ./configure && make
+
+WORKDIR /build/run
+CMD ["../src/services"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         libc6-dev \
         ca-certificates \
+        python3 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 COPY . .
 
-RUN ./configure && make
+RUN python3 lang/langcomp.py && ./configure && make
 
 WORKDIR /build/run
 CMD ["../src/services"]


### PR DESCRIPTION
Bootstraps CI for azzurra/services (none existed before — azzurra/bahamut ships a Dockerfile, but services had neither).

## What's in here

- **`Dockerfile`** — debian:trixie + `build-essential libc6-dev`, runs `./configure && make`. No `libssl-dev` (services does not link OpenSSL; password hashing is internal via `crypt_shs1.c`), no multilib (services is 64-bit-native since the features/64bit merge).
- **`.github/workflows/build.yml`** — two jobs:
  - `build` — matrix over `debian:trixie`, `debian:bookworm`, `ubuntu:24.04`, each in a container. Installs apt deps, runs configure + make, verifies the binary. Uploads `src/services` as an artifact from the trixie build (7-day retention).
  - `docker` — builds the Dockerfile and smoke-checks that `/build/src/services` is present.

Triggers: push to `master` / `develop` / `features/**` / `feat/**` / `ci/**`, and PRs against `master` or `develop`.

## Verification

Locally verified `docker build .` succeeds end-to-end (debian trixie).
The workflow is running on my fork right now against `ci/bootstrap` — green run will show up at https://github.com/vjt/services/actions once it lands.

## Follow-up

The current CI verifies the C build but not the lang compilation step (the shipped `lang/langcomp` is a 32-bit ELF binary that needs `libc6-i386` to run; multilib was dropped from this CI to keep it minimal). That can be added when/if the Python replacement from #8 lands, or via a separate multilib-enabled Dockerfile stage.