### PR TITLE
main: add -F flag to stay in foreground

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -100,6 +100,11 @@ int global_force_backup_count = 0;
 /* Contains a message as to why services is terminating */
 static char QUIT_MESSAGE[BUFSIZE];
 
+/* Set via -F on the command line — skip the fork() detachment in
+ * initialize() so services stays on PID 1 under a process supervisor
+ * (docker, systemd, etc) that expects the main process not to daemonize. */
+static BOOL foreground = FALSE;
+
 /* How many database expirations did we go through? */
 static unsigned long int expire_count = 1;
 
@@ -237,17 +242,25 @@ static BOOL initialize() {
 
 	region_init();
 
-	/* Detach ourselves. */
+	/* Detach ourselves — unless -F was given, in which case we stay
+	 * attached so the process supervisor (docker, systemd, ...) sees
+	 * services as the main process and can deliver signals to it. */
+	if (!foreground) {
 
-	if ((pid = fork()) < 0) {
+		if ((pid = fork()) < 0) {
 
-		perror("fork()");
-		return FALSE;
+			perror("fork()");
+			return FALSE;
+		}
+		else if (pid != 0) {
+
+			fprintf(stderr, "\nRunning in background (pid: %d)\n\n", pid);
+			exit(EXIT_SUCCESS);
+		}
 	}
-	else if (pid != 0) {
+	else {
 
-		fprintf(stderr, "\nRunning in background (pid: %d)\n\n", pid);
-		exit(EXIT_SUCCESS);
+		fprintf(stderr, "\nRunning in foreground (pid: %d)\n\n", (int) getpid());
 	}
 
 	if (setpgid(0, 0) < 0) {
@@ -577,6 +590,24 @@ int main(int ac, char **av, char **envp) {
 		*ptr = '\0';
 
 		chdir(buf);
+	}
+
+	/* Parse the handful of flags we accept. Keep this trivial: services has
+	 * historically taken no arguments. */
+	{
+		int i;
+
+		for (i = 1; i < ac; i++) {
+
+			if (strcmp(av[i], "-F") == 0)
+				foreground = TRUE;
+			else {
+
+				fprintf(stderr, "Usage: %s [-F]\n", av[0]);
+				fprintf(stderr, "  -F   run in foreground (do not fork at startup)\n");
+				return EXIT_FAILURE;
+			}
+		}
 	}
 
 	time(&NOW);


### PR DESCRIPTION
## Summary

`initialize()` forks unconditionally at startup and exits the parent, which breaks every supervisor that needs the services process to remain on PID 1:

- `docker run ...` — the container exits cleanly (0) the moment `Running in background (pid: N)` is printed, because the docker-visible process (the parent) has `exit(EXIT_SUCCESS)`'d. The daemonised child keeps running but is an orphan nobody's watching.
- `systemd` units with `Type=simple` — same issue. Either you switch to `Type=forking` with a `PIDFile=` knob (and we write `data/services.pid` *after* fork, so ordering is racy) or the unit flips between `activating` and `inactive`.
- `tini` / `dumb-init` / any PID-1 wrapper — defeated for the same reason.

This PR adds `-F` to make services skip the fork and run in the foreground. Without `-F` behaviour is bit-for-bit identical to today.

## What changed

- `src/main.c` — one file, +38/-7.
- New file-static `BOOL foreground = FALSE;` near the other locals.
- `main()`: after the argv[0] path fix, a trivial argv loop that sets `foreground = TRUE` on `-F` and prints a one-line usage for anything else.
- `initialize()`: the `fork() / exit(EXIT_SUCCESS)` block is gated on `!foreground`. In foreground mode we print `Running in foreground (pid: N)` for parity with the old background-pid banner. Everything after (`setpgid`, `write_pidfile`, signal handlers, main loop) is untouched.

## Why this shape

- Minimal-surface change: no new file, no header changes, no build system touch. If `-F` is never passed, the diff is functionally dead code.
- No `getopt()` pull-in just to handle one flag. Matches the existing ad-hoc style in `main()` (the argv[0] / chdir(dirname) block above).
- Banner text follows the existing `Running in background (pid: %d)` wording so log scrapers that look for it still work.

## Test plan

- [x] Clean build: `./configure && cd lang && python3 langcomp.py && cd .. && make` → `gcc -Wall -Wshadow -Wcast-align -Wsign-compare`, 0 warnings.
- [x] `./services -F` in `run/` works as before (no fork, startup continues up to the conf-file stage under the caller's tty).
- [x] `./services` (no flag) still forks and exits parent immediately, unchanged behaviour.
- [ ] Full stack bring-up under docker — this PR is a pre-req for [azzurra/infra#2](https://github.com/azzurra/infra/pull/2)'s testnet smoke, which needs the services container to stay on PID 1. Will verify once this is merged and `SERVICES_REF` in the infra Dockerfile points at a commit that includes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)