### PR TITLE
tagline: bump max length 260 -> 400, replace magic number with named constant

### DIFF
--- a/inc/tagline.h
+++ b/inc/tagline.h
@@ -63,27 +63,39 @@ typedef	Tagline_V10_32		Tagline32;
 /*
  * TAGLINE_MAX_LEN -- hard cap on tagline text length, in bytes.
  *
- * This is not an arbitrary knob. Taglines are broadcast through
- * send_globops() (see tagline_show() and handle_tagline() in tagline.c),
- * which ultimately produces an IRC server message of the form:
+ * This is not an arbitrary knob. The tightest constraint is not storage
+ * or the inbound PRIVMSG the operator sends to OperServ (servers use a
+ * nick-only prefix when propagating client traffic, per RFC 1459 s.2.3
+ * and bahamut convention, which leaves ample room). It is the *outbound*
+ * broadcast produced by send_globops() in handle_tagline() and
+ * tagline_show(), which bahamut turns into a NOTICE to every +g operator
+ * (see src/send.c:send_globops in bahamut):
  *
- *     :<server> NOTICE $* :<OperServ> (through <oper>) added the
- *     following tagline: <text>\r\n
+ *     :<server> NOTICE <destnick> :*** Global -- \2<caller>\2
+ *     (through \2<oper>\2) added the following tagline: <text>\r\n
  *
- * The IRC protocol caps a single line at 512 bytes including the trailing
- * CR-LF (RFC 1459 section 2.3.1). The fixed overhead above -- server
- * prefix, command, target, boilerplate and the optional "(through <oper>)"
- * variant emitted when an operator acts via a service -- eats roughly
- * 100-110 bytes in realistic cases. 400 leaves comfortable headroom for
- * multibyte glyphs and long operator/server names without bumping into the
- * 512-byte ceiling.
+ * The IRC protocol caps a single line at 512 bytes including the
+ * trailing CR-LF (RFC 1459 s.2.3.1). Worst-case byte budget:
  *
- * Before raising this value, re-derive the worst-case envelope against
- * every send_globops() call site that embeds a tagline: blind increases
- * cause silent truncation at the uplink (bahamut) with no feedback to the
- * originating operator.
+ *     `:<server>` (HOSTMAX=63) + ` NOTICE ` (8) + `<destnick>`
+ *     (NICKMAX=32) + ` :*** Global -- ` (16) + bold markers + `<caller>`
+ *     (NICKMAX=32) + ` (through ` (10) + bold markers + `<oper>`
+ *     (NICKMAX=32) + `) added the following tagline: ` (31) + <text>
+ *     + `\r\n` (2) ~= 230 + text
+ *
+ * So the theoretical worst case caps text at ~280, though realistic
+ * Azzurra params (server name ~21, operator nicks ~8-12) leave comfortable
+ * headroom. 350 keeps us well clear of truncation across both realistic
+ * and near-worst-case combinations without pushing the limit.
+ *
+ * Before raising this value, re-derive both envelopes (services-side
+ * send_globops() and bahamut's send_globops() NOTICE wrapper) against
+ * every call site that embeds a tagline. Blind increases cause silent
+ * truncation at the receiving server with no feedback to the originating
+ * operator -- the stored tagline is fine, but the GLOBOPS confirmation
+ * message seen by +g opers gets its tail cut.
  */
-#define TAGLINE_MAX_LEN				400
+#define TAGLINE_MAX_LEN				350
 
 
 /*********************************************************

--- a/inc/tagline.h
+++ b/inc/tagline.h
@@ -60,6 +60,31 @@ typedef	Tagline_V10_32		Tagline32;
 #define	TAGLINE_DB_CURRENT_VERSION		10
 #define TAGLINE_DB_SUPPORTED_VERSION	"10"
 
+/*
+ * TAGLINE_MAX_LEN -- hard cap on tagline text length, in bytes.
+ *
+ * This is not an arbitrary knob. Taglines are broadcast through
+ * send_globops() (see tagline_show() and handle_tagline() in tagline.c),
+ * which ultimately produces an IRC server message of the form:
+ *
+ *     :<server> NOTICE $* :<OperServ> (through <oper>) added the
+ *     following tagline: <text>\r\n
+ *
+ * The IRC protocol caps a single line at 512 bytes including the trailing
+ * CR-LF (RFC 1459 section 2.3.1). The fixed overhead above -- server
+ * prefix, command, target, boilerplate and the optional "(through <oper>)"
+ * variant emitted when an operator acts via a service -- eats roughly
+ * 100-110 bytes in realistic cases. 400 leaves comfortable headroom for
+ * multibyte glyphs and long operator/server names without bumping into the
+ * 512-byte ceiling.
+ *
+ * Before raising this value, re-derive the worst-case envelope against
+ * every send_globops() call site that embeds a tagline: blind increases
+ * cause silent truncation at the uplink (bahamut) with no feedback to the
+ * originating operator.
+ */
+#define TAGLINE_MAX_LEN				400
+
 
 /*********************************************************
  * Global variables                                      *

--- a/src/tagline.c
+++ b/src/tagline.c
@@ -327,9 +327,9 @@ void handle_tagline(CSTR source, User *callerUser, ServiceCommandData *data) {
 			return;
 		}
 
-		if ((len = str_len(text)) > 260) {
+		if ((len = str_len(text)) > TAGLINE_MAX_LEN) {
 
-			send_notice_to_user(s_OperServ, callerUser, "The maximum length for a tagline is 260 characters. Your tagline has %d.", len);
+			send_notice_to_user(s_OperServ, callerUser, "The maximum length for a tagline is %d characters. Your tagline has %d.", TAGLINE_MAX_LEN, len);
 			return;
 		}
 
@@ -417,7 +417,7 @@ void handle_tagline(CSTR source, User *callerUser, ServiceCommandData *data) {
 			return;
 		}
 
-		if (str_len(text) > 260) {
+		if (str_len(text) > TAGLINE_MAX_LEN) {
 
 			send_notice_to_user(s_OperServ, callerUser, "Tagline not found.");
 			return;


### PR DESCRIPTION
## Summary

- Add `TAGLINE_MAX_LEN` in `inc/tagline.h` with an English block comment explaining *why* the value is not a free parameter (512-byte IRC line cap, `send_globops()` envelope math).
- Replace the three literal `260` in `src/tagline.c` (ADD bound, DEL bound, error message) with `TAGLINE_MAX_LEN`; the user-facing error now formats the constant via `%d` instead of hardcoding the number in the English string, so the two will never drift.
- Bump the cap from 260 to **350** bytes.

## Rationale

Requested on #it-opers by @Hypnotize (2026-04-21): existing limit felt tight and he wanted an increase. The final shape — named constant in the header, block comment documenting the constraint, no raw magic number left — is his direct requirement ("magic number non ne voglio vedere, constant" / "metti un commento in inglese sopra la costante per spiegare che non puoi bumpare arbitrariamente oltre").

## Safety / Byte budget

Final value revised from the initial 400 to 350 after review with @Essency, who correctly flagged that the outbound NOTICE wrap in bahamut's `send_globops()` includes *both* the services-side `*** Global -- from <caller>: ...` framing **and** the ircd-side `:<server> NOTICE <dest> :*** Global -- ...` envelope. Worst-case (HOSTMAX=63, NICKMAX=32 across caller/through/destnick, bold markers, full fixed tail) lands at ~230 bytes of overhead, leaving ~280 for the text. 350 is past the theoretical worst case for fully-loaded parameters but stays safely under 512 for every realistic Azzurra combination (server name ~16–21, oper nicks ~8–12) — see the block comment above `TAGLINE_MAX_LEN` for the full derivation and the explicit warning to re-derive both envelopes before bumping again.

## Test plan

- [x] Local build clean with `make -C src` (no warnings introduced).
- [x] Ephemeral testnet smoke — bahamut `master` + services `refs/pull/14/head`, 3-server topology (hub + leaf-v4 + leaf-v6 + services):
  - [x] `TAGLINE ADD <349-byte string>` → `Your tagline has been added successfully.`
  - [x] `TAGLINE ADD <350-byte string>` → `Your tagline has been added successfully.`
  - [x] `TAGLINE ADD <351-byte string>` → `The maximum length for a tagline is 350 characters. Your tagline has 351.` (constant + actual length both via `%d`, no drift).
  - [x] `TAGLINE LIST` after the run shows the 349 and 350 entries (the 351 was rejected before storage).
  - [x] `:hub.azzurra.chat NOTICE testoper :*** Global -- from OperServ: testoper added the following tagline: <350-byte text>` GLOBOPS broadcast measured at 454 bytes on the wire, well under the 512 cap.

### Smoke harness notes

Auth trick for the testnet: REGISTER → /OPER → IDENTIFY in that order. `check_oper()` at `src/oper.c:603` only promotes past `ULEVEL_HOP` when `user_is_ircop()` is already true, so IDENTIFYing before /OPER leaves `user->oper == NULL` and every ULEVEL_MASTER dispatch returns `Access denied`. With `testoper` also configured as `M:` in services.conf, `check_oper()` auto-creates the Master oper entry (oper.c:586-591) on first identify — no pre-seeded oper db needed.

```
=== ADD len=349 (wire line 381) ===
:OperServ!service@azzurra.chat NOTICE testoper :Your tagline has been added successfully.

=== ADD len=350 (wire line 382) ===
:hub.azzurra.chat NOTICE testoper :*** Global -- from OperServ: testoper added the following tagline: A350-xxx...(350 bytes of text)
:OperServ!service@azzurra.chat NOTICE testoper :Your tagline has been added successfully.

=== ADD len=351 (wire line 383) ===
:OperServ!service@azzurra.chat NOTICE testoper :The maximum length for a tagline is 350 characters. Your tagline has 351.
```
