### PR TITLE
lang: emit CRLF-separator blank line after email Subject headers

### DIFF
--- a/lang/English.lang
+++ b/lang/English.lang
@@ -1961,7 +1961,6 @@ CS_SENDPASS_ERROR_PASSRESET_ON
 	A password reset is already in progress for channel %s. Use AUTHRESET to cancel it, or wait for it to expire.
 CS_SENDPASS_EMAIL_SUBJECT_RPWD
 	Subject: Password reset code for channel %s
-
 	
 	
 CS_SENDPASS_EMAIL_RPWD

--- a/lang/English.lang
+++ b/lang/English.lang
@@ -164,6 +164,7 @@ CS_DROP_CODE_SENT
 CS_DROP_EMAIL_SUBJECT
 	Subject: Channel drop authorization on %s
 	
+	
 CS_DROP_EMAIL_TEXT
 	You or someone else has recently requested your channel to be dropped.
 	If you wish this action to be taken, follow these steps:
@@ -395,6 +396,7 @@ CS_REGISTER_SYNTAX_ERROR
 CS_REMIND_EMAIL_SUBJECT
 	Subject: Channel registration on %s
 	
+	
 CS_REMIND_EMAIL_TEXT
 	Your channel %s will expire in %d days.
 	To avoid this, either you or one of your channel operators must join it at least once before it expires.
@@ -414,6 +416,7 @@ CS_RESTRICTED_KICK_REASON
 	You are not permitted to be on this channel.
 CS_SENDPASS_EMAIL_SUBJECT
 	Subject: %s channel password
+	
 	
 CS_SENDPASS_EMAIL_TEXT
 	Password request sent by: %s
@@ -1119,6 +1122,7 @@ MS_READ_SYNTAX_ERROR
 MS_SENDTO_EMAIL_SUBJECT
 	Subject: New memo for nick %s
 	
+	
 MS_SENDTO_EMAIL_TEXT
 	Memo from: %s
 	To channel: %s
@@ -1148,6 +1152,7 @@ MS_SENDTO_SYNTAX_ERROR
 	Syntax: SENDTO #channel [VOP|AOP|SOP|CF] message
 MS_SEND_EMAIL_SUBJECT
 	Subject: New memo for nick %s
+	
 	
 MS_SEND_EMAIL_TEXT
 	Memo from: %s
@@ -1303,6 +1308,7 @@ NS_DROP_CODE_SENT
 	You will receive a drop authorization code in your E-Mail (%s) shortly. Please follow the instructions of the email to complete the action of dropping this nick.
 NS_DROP_EMAIL_SUBJECT
 	Subject: %s nickname drop code
+	
 	
 NS_DROP_EMAIL_TEXT
 	You or someone has recently requested your nickname to be dropped.
@@ -1470,6 +1476,7 @@ NS_RECOVER_SYNTAX_ERROR
 NS_REGISTER_EMAIL_SUBJECT
 	Subject: %s nickname registration confirmation
 	
+	
 NS_REGISTER_EMAIL_TEXT_1
 	Thank you for flying %s!
 	The authorization code for your nick is: %lu 
@@ -1535,6 +1542,7 @@ NS_RELEASE_SYNTAX_ERROR
 NS_REMIND_EMAIL_SUBJECT
 	Subject: Nickname registration on %s
 	
+	
 NS_REMIND_EMAIL_TEXT
 	Your nickname %s will expire in %d days.
 	To avoid this, you must identify to it at least once before it expires.
@@ -1569,6 +1577,7 @@ NS_SENDCODE_EMAIL_MAIL2
 NS_SENDCODE_EMAIL_SUBJECT
 	Subject: Authorization code for %s of the nick %s
 	
+	
 NS_SENDCODE_EMAIL_SUBJECT_AUTH
 	the registration
 NS_SENDCODE_EMAIL_SUBJECT_DROP
@@ -1586,6 +1595,7 @@ NS_SENDCODE_SYNTAX_ERROR
 	Syntax: SENDCODE nickname
 NS_SENDPASS_EMAIL_SUBJECT
 	Subject: Password for nick %s
+	
 	
 NS_SENDPASS_EMAIL_TEXT
 	Password retreival by: %s
@@ -1634,6 +1644,7 @@ NS_SET_EMAIL_SHOW
 	E-Mail address for %s is now public.
 NS_SET_EMAIL_SUBJECT
 	Subject: Nickname %s E-Mail change
+	
 	
 NS_SET_EMAIL_TEXT_1
 	This E-Mail change request was sent by
@@ -1951,6 +1962,8 @@ CS_SENDPASS_ERROR_PASSRESET_ON
 CS_SENDPASS_EMAIL_SUBJECT_RPWD
 	Subject: Password reset code for channel %s
 
+	
+	
 CS_SENDPASS_EMAIL_RPWD
 	Password reset request issued by: %s
 	Received: %s

--- a/lang/French.lang
+++ b/lang/French.lang
@@ -1965,7 +1965,6 @@ CS_SENDPASS_ERROR_PASSRESET_ON
 	Une reinitialisation de mot de passe est deja en cours pour le canal %s. Utilisez AUTHRESET pour l'annuler, ou attendez son expiration.
 CS_SENDPASS_EMAIL_SUBJECT_RPWD
 	Subject: Code de reinitialisation de mot de passe pour le canal %s
-
 	
 	
 CS_SENDPASS_EMAIL_RPWD

--- a/lang/French.lang
+++ b/lang/French.lang
@@ -164,6 +164,7 @@ CS_DROP_CODE_SENT
 CS_DROP_EMAIL_SUBJECT
 	Subject: Code d'autorisation pour confirmer l'effacement de ton canal sur %s
 	
+	
 CS_DROP_EMAIL_TEXT
 	Toi ou quelqu'un d'autre a demandé l'effacement de ton canal.
 	Si tu veux le confirmer, suis les instructions écrites ci-dessous:
@@ -396,6 +397,7 @@ CS_REGISTER_SYNTAX_ERROR
 CS_REMIND_EMAIL_SUBJECT
 	Subject: Registration de ton canal sur %s
 	
+	
 CS_REMIND_EMAIL_TEXT
 	Le canal %s expirera entre %d jours.
 	Si tu veux eviter qu'il sera effacé, toi ou un de tes opérateurs doit y entrer au moins une foix avant la date de l'expiration.
@@ -415,6 +417,7 @@ CS_RESTRICTED_KICK_REASON
 	Tu n'a pas la permission d'entrer dans ce canal.
 CS_SENDPASS_EMAIL_SUBJECT
 	Subject: Mot de passe du canal %s
+	
 	
 CS_SENDPASS_EMAIL_TEXT
 	Mot de passe envoyé par: %s
@@ -1120,6 +1123,7 @@ MS_READ_SYNTAX_ERROR
 MS_SENDTO_EMAIL_SUBJECT
 	Subject: Nouveau memo pour le nick %s
 	
+	
 MS_SENDTO_EMAIL_TEXT
 	Memo de la part de: %s
 	Au canal: %s
@@ -1149,6 +1153,7 @@ MS_SENDTO_SYNTAX_ERROR
 	Syntaxe: SENDTO #canal [VOP|AOP|SOP|CF] texte
 MS_SEND_EMAIL_SUBJECT
 	Subject: Nouveau memo pour le nick %s
+	
 	
 MS_SEND_EMAIL_TEXT
 	Memo de la part de: %s
@@ -1304,6 +1309,7 @@ NS_DROP_CODE_SENT
 	Dans peu de temps tu recevras un E-Mail à l'adresse %s qui contiendra le code de drop nécessaire pour autoriser l'effacement de la registration de ton nick. Suis les instructions dans l'E-Mail pour compléter la procédure.
 NS_DROP_EMAIL_SUBJECT
 	Subject: Code d'autorisation pour effacer ton nick sur %s
+	
 	
 NS_DROP_EMAIL_TEXT
 	Toi ou quelqu'un d'autre a demandé l'effacement de ton nick.
@@ -1471,6 +1477,7 @@ NS_RECOVER_SYNTAX_ERROR
 NS_REGISTER_EMAIL_SUBJECT
 	Subject: Confirme de l'enregistrement du nick sur %s.
 	
+	
 NS_REGISTER_EMAIL_TEXT_1
 	Merci d'avoir choisi %s!
 	Le code d'autorisation de ton nick est: %lu 
@@ -1540,6 +1547,7 @@ NS_RELEASE_SYNTAX_ERROR
 NS_REMIND_EMAIL_SUBJECT
 	Subject: enregistrement de ton nick sur %s
 	
+	
 NS_REMIND_EMAIL_TEXT
 	Le nick %s expirera en %d jours.
 	Si tu veux eviter qu'il soit effacé, tu dois t'identifier au moins une fois avant la date d'échéance.
@@ -1573,6 +1581,7 @@ NS_SENDCODE_EMAIL_MAIL2
 NS_SENDCODE_EMAIL_SUBJECT
 	Subject: Code d'autorisation pour %s du nick %s
 	
+	
 NS_SENDCODE_EMAIL_SUBJECT_AUTH
 	l'enregistrement
 NS_SENDCODE_EMAIL_SUBJECT_DROP
@@ -1590,6 +1599,7 @@ NS_SENDCODE_SYNTAX_ERROR
 	Syntax: SENDCODE nickname
 NS_SENDPASS_EMAIL_SUBJECT
 	Subject: Mot de passe du nick %s
+	
 	
 NS_SENDPASS_EMAIL_TEXT
 	Demande de mot de passe envoyée par: %s
@@ -1638,6 +1648,7 @@ NS_SET_EMAIL_SHOW
 	L'adresse E-Mail du nick %s a été rendue visible.
 NS_SET_EMAIL_SUBJECT
 	Subject: Changement d'E-Mail du nick %s
+	
 	
 NS_SET_EMAIL_TEXT_1
 	Demande de changement d'E-Mail envoyée par
@@ -1955,6 +1966,8 @@ CS_SENDPASS_ERROR_PASSRESET_ON
 CS_SENDPASS_EMAIL_SUBJECT_RPWD
 	Subject: Code de reinitialisation de mot de passe pour le canal %s
 
+	
+	
 CS_SENDPASS_EMAIL_RPWD
 	Demande de reinitialisation de mot de passe envoyee par: %s
 	Recue: %s

--- a/lang/Italian.lang
+++ b/lang/Italian.lang
@@ -1965,7 +1965,6 @@ CS_SENDPASS_ERROR_PASSRESET_ON
 	Un reset password e' gia' in corso per il canale %s. Usa AUTHRESET per annullarlo, o attendi che scada.
 CS_SENDPASS_EMAIL_SUBJECT_RPWD
 	Subject: Codice di reset password per il canale %s
-
 	
 	
 CS_SENDPASS_EMAIL_RPWD

--- a/lang/Italian.lang
+++ b/lang/Italian.lang
@@ -164,6 +164,7 @@ CS_DROP_CODE_SENT
 CS_DROP_EMAIL_SUBJECT
 	Subject: Codice di autorizzazione per droppare il tuo canale su %s
 	
+	
 CS_DROP_EMAIL_TEXT
 	Tu o qualcun altro ha richiesto la cancellazione del tuo canale.
 	Se vuoi confermare il drop, segui le istruzioni riportate qui sotto:
@@ -396,6 +397,7 @@ CS_REGISTER_SYNTAX_ERROR
 CS_REMIND_EMAIL_SUBJECT
 	Subject: Registrazione del tuo canale su %s
 	
+	
 CS_REMIND_EMAIL_TEXT
 	Il canale %s scadra' fra %d giorni.
 	Se vuoi evitare che venga cancellato, tu o un tuo operatore deve entrarci almeno una volta prima della data di scadenza.
@@ -415,6 +417,7 @@ CS_RESTRICTED_KICK_REASON
 	Non hai il permesso di entrare in questo canale.
 CS_SENDPASS_EMAIL_SUBJECT
 	Subject: Password del canale %s
+	
 	
 CS_SENDPASS_EMAIL_TEXT
 	Richiesta di password inviata da: %s
@@ -1120,6 +1123,7 @@ MS_READ_SYNTAX_ERROR
 MS_SENDTO_EMAIL_SUBJECT
 	Subject: Nuovo memo per il nick %s
 	
+	
 MS_SENDTO_EMAIL_TEXT
 	Memo da parte di: %s
 	Al canale: %s
@@ -1149,6 +1153,7 @@ MS_SENDTO_SYNTAX_ERROR
 	Sintassi: SENDTO #canale [VOP|AOP|SOP|CF] testo
 MS_SEND_EMAIL_SUBJECT
 	Subject: Nuovo memo per il nick %s
+	
 	
 MS_SEND_EMAIL_TEXT
 	Memo da parte di: %s
@@ -1304,6 +1309,7 @@ NS_DROP_CODE_SENT
 	A breve riceverai una E-Mail all'indirizzo %s contenente il drop code necessario per autorizzare la cancellazione della registrazione del tuo nick. Segui le istruzioni contenute nell'E-Mail per completare il processo.
 NS_DROP_EMAIL_SUBJECT
 	Subject: Codice di autorizzazione per droppare il tuo nick su %s
+	
 	
 NS_DROP_EMAIL_TEXT
 	Tu o qualcun altro ha richiesto la cancellazione del tuo nick.
@@ -1471,6 +1477,7 @@ NS_RECOVER_SYNTAX_ERROR
 NS_REGISTER_EMAIL_SUBJECT
 	Subject: Conferma della registrazione del nick %s.
 	
+	
 NS_REGISTER_EMAIL_TEXT_1
 	Grazie per aver scelto %s!
 	Il codice di autorizzazione del tuo nick e': %lu 
@@ -1540,6 +1547,7 @@ NS_RELEASE_SYNTAX_ERROR
 NS_REMIND_EMAIL_SUBJECT
 	Subject: Registrazione del tuo nick su %s
 	
+	
 NS_REMIND_EMAIL_TEXT
 	Il nick %s scadra' fra %d giorni.
 	Se vuoi evitare che venga cancellato, devi identificartici almeno una volta prima della data di scadenza.
@@ -1573,6 +1581,7 @@ NS_SENDCODE_EMAIL_MAIL2
 NS_SENDCODE_EMAIL_SUBJECT
 	Subject: Codice di autorizzazione per %s del nick %s
 	
+	
 NS_SENDCODE_EMAIL_SUBJECT_AUTH
 	la registrazione
 NS_SENDCODE_EMAIL_SUBJECT_DROP
@@ -1590,6 +1599,7 @@ NS_SENDCODE_SYNTAX_ERROR
 	Syntax: SENDCODE nickname
 NS_SENDPASS_EMAIL_SUBJECT
 	Subject: Password del nick %s
+	
 	
 NS_SENDPASS_EMAIL_TEXT
 	Richiesta di password inviata da: %s
@@ -1638,6 +1648,7 @@ NS_SET_EMAIL_SHOW
 	L'indirizzo E-Mail del nick %s e' stato reso visibile.
 NS_SET_EMAIL_SUBJECT
 	Subject: Cambio mail del nick %s
+	
 	
 NS_SET_EMAIL_TEXT_1
 	Richiesta di cambio di indirizzo E-Mail inviata da
@@ -1955,6 +1966,8 @@ CS_SENDPASS_ERROR_PASSRESET_ON
 CS_SENDPASS_EMAIL_SUBJECT_RPWD
 	Subject: Codice di reset password per il canale %s
 
+	
+	
 CS_SENDPASS_EMAIL_RPWD
 	Richiesta di reset password inviata da: %s
 	Ricevuta: %s

--- a/lang/Spanish.lang
+++ b/lang/Spanish.lang
@@ -1965,7 +1965,6 @@ CS_SENDPASS_ERROR_PASSRESET_ON
 	Ya hay un reseteo de contrasena en curso para el canal %s. Usa AUTHRESET para cancelarlo, o espera a que caduque.
 CS_SENDPASS_EMAIL_SUBJECT_RPWD
 	Subject: Codigo de reseteo de contrasena para el canal %s
-
 	
 	
 CS_SENDPASS_EMAIL_RPWD

--- a/lang/Spanish.lang
+++ b/lang/Spanish.lang
@@ -164,6 +164,7 @@ CS_DROP_CODE_SENT
 CS_DROP_EMAIL_SUBJECT
 	Subject: Codigo de autorizaciòn para dar de baja tu canal en %s
 	
+	
 CS_DROP_EMAIL_TEXT
 	Tu o alguien mas ha pedido la anulaciòn de tu canal.
 	Si quieres confirmar el drop, sigue las instrucciones reportadas en seguida:
@@ -396,6 +397,7 @@ CS_REGISTER_SYNTAX_ERROR
 CS_REMIND_EMAIL_SUBJECT
 	Subject: Registraciòn de tu canal en %s
 	
+	
 CS_REMIND_EMAIL_TEXT
 	El canal %s expirarà en %d dias.
 	Si quieres evitar que se anule, tu o algun otro operador tienen que entrar minimo una vez antes de la fecha de expiraciòn.
@@ -415,6 +417,7 @@ CS_RESTRICTED_KICK_REASON
 	No tienes ninguna autorizaciòn para acceder a este canal.
 CS_SENDPASS_EMAIL_SUBJECT
 	Subject: Password del canal %s
+	
 	
 CS_SENDPASS_EMAIL_TEXT
 	Solicitaciòn de contraseña enviada por: %s
@@ -1120,6 +1123,7 @@ MS_READ_SYNTAX_ERROR
 MS_SENDTO_EMAIL_SUBJECT
 	Subject: Nuevo memo para el nick %s
 	
+	
 MS_SENDTO_EMAIL_TEXT
 	Memo de parte de: %s
 	Para el canal: %s
@@ -1149,6 +1153,7 @@ MS_SENDTO_SYNTAX_ERROR
 	Sintaxis: SENDTO #canal [VOP|AOP|SOP|CF] texto
 MS_SEND_EMAIL_SUBJECT
 	Subject: Nuevo memo para el nick %s
+	
 	
 MS_SEND_EMAIL_TEXT
 	Memo de parte de: %s
@@ -1304,6 +1309,7 @@ NS_DROP_CODE_SENT
 	En unos momentos recibiràs un E-Mail en la direcciòn %s con el codigo de drop necesario para autorizar la registraciòn de tu nick. Sigue las instrucciones del Email para completar el proceso.
 NS_DROP_EMAIL_SUBJECT
 	Subject: Codico de autorizaciòn para anular tu nick en %s
+	
 	
 NS_DROP_EMAIL_TEXT
 	Tu o alguien mas pidiò la anulaciòn de tu nick.
@@ -1471,6 +1477,7 @@ NS_RECOVER_SYNTAX_ERROR
 NS_REGISTER_EMAIL_SUBJECT
 	Subject: Confirmaciòn de la registraciòn del nick %s.
 	
+	
 NS_REGISTER_EMAIL_TEXT_1
 	Gracias por haber escogido %s!
 	El codigo de autorizaciòn para tu nick es: %lu 
@@ -1540,6 +1547,7 @@ NS_RELEASE_SYNTAX_ERROR
 NS_REMIND_EMAIL_SUBJECT
 	Subject: Registraciòn de tu nick en %s
 	
+	
 NS_REMIND_EMAIL_TEXT
 	El nick %s expirarà en %d dias.
 	Si no quieres que esto pase, tienes que identificarte minimo una vez antes que se te expire.
@@ -1573,6 +1581,7 @@ NS_SENDCODE_EMAIL_MAIL2
 NS_SENDCODE_EMAIL_SUBJECT
 	Subject: Codigo de autorizaciòn para %s del nick %s
 	
+	
 NS_SENDCODE_EMAIL_SUBJECT_AUTH
 	la registraciòn
 NS_SENDCODE_EMAIL_SUBJECT_DROP
@@ -1590,6 +1599,7 @@ NS_SENDCODE_SYNTAX_ERROR
 	Syntax: SENDCODE nickname
 NS_SENDPASS_EMAIL_SUBJECT
 	Subject: Contraseña del nick %s
+	
 	
 NS_SENDPASS_EMAIL_TEXT
 	Pedida de contraseña enviada por: %s
@@ -1638,6 +1648,7 @@ NS_SET_EMAIL_SHOW
 	La direcciòn de Email del nick %s ha sido ajustada en invisible.
 NS_SET_EMAIL_SUBJECT
 	Subject: Cambio direccion Email del nick %s
+	
 	
 NS_SET_EMAIL_TEXT_1
 	Pedida de cambio de direcciòn E-Mail enviada por
@@ -1955,6 +1966,8 @@ CS_SENDPASS_ERROR_PASSRESET_ON
 CS_SENDPASS_EMAIL_SUBJECT_RPWD
 	Subject: Codigo de reseteo de contrasena para el canal %s
 
+	
+	
 CS_SENDPASS_EMAIL_RPWD
 	Solicitud de reseteo de contrasena enviada por: %s
 	Recibida: %s


### PR DESCRIPTION
## Summary

- Email Subject headers compiled by \`langcomp\` currently end with a single \`\n\` because their \`.lang\` entries have only one trailing tab-empty terminator.
- When \`do_sendpass\` / \`do_sendcode\` fprintfs the Subject line followed by body text, the output skips the RFC 5322 blank-line separator between headers and body.
- Strict parsers (e.g. the resend.com SMTP relay that now fronts \`nickserv-bounces@azzurra.chat\`) reject these with 554 "Failed to parse email message", so SENDPASS / SENDCODE / RESETPASS / DROP / REGISTER / REMIND / SET / SEND / SENDTO mails have stopped being delivered.
- Fix adds a second tab-empty terminator to every \`*_EMAIL_SUBJECT\` entry that contains an actual \`Subject: ...\` line, across \`IT/US/ES/FR\`. Compiled \`.clng\` bodies now end with \`\n\n\`, providing the required blank line.

## Notes

- 12 subject entries × 4 languages = 48 body terminations fixed.
- Format-arg sub-entries (\`_AUTH\`, \`_DROP\`, \`_MAIL\`, \`_RPWD\` for \`NS_SENDCODE_EMAIL_SUBJECT\`) are interpolated into the parent Subject line via \`%s\` and are intentionally left alone.
- No \`langcomp.py\` change: the fix is pure data. Hot-reloadable via \`rehash\` once the \`.clng\` files are regenerated.
- \`inc/lang_msg_svc.h\` unchanged (message IDs stable).

## Test plan

- [x] \`python3 lang/langcomp.py\` produces the 4 \`svc*.clng\` files without errors
- [x] Every compiled Subject entry body now ends with \`\n\n\` (verified via struct-parse of IT clng for all 12 entries)
- [x] Non-subject entries (e.g. \`NS_SENDCODE_EMAIL_SUBJECT_AUTH\` = \`"la registrazione"\`) unchanged
- [ ] Deploy testnet \`.clng\`, trigger \`/ns SENDPASS\` / \`/ns SENDCODE\`, confirm resend.com accepts (no 554)
- [ ] Deploy prod after staff OK