### PR TITLE
Make expand_ipv6 use caller-provided buffer

### DIFF
--- a/inc/misc.h
+++ b/inc/misc.h
@@ -62,7 +62,7 @@ extern HOST_TYPE host_type(CSTR host, short int *dotsCountPtr);
 extern BOOL year_is_leap(const int year);
 extern BOOL validate_date(const int dateYear, const int dateMonth, const int dateDay);
 
-extern char *expand_ipv6(CSTR input);
+extern void expand_ipv6(CSTR input, STR output, size_t output_size);
 
 extern char *convert_time(char *buffer, size_t len, time_t timeSpan, const LANG_ID langID);
 extern char *expire_left(char *buffer, size_t len, time_t expiry);

--- a/src/crypt_userhost.c
+++ b/src/crypt_userhost.c
@@ -270,7 +270,8 @@ STR crypt_userhost(CSTR real, HOST_TYPE htype, short int dotsCount) {
 
 	size_t			len, virlen;
 	int32_t			hash;
-	char			*ptr;
+	char			*ptr, *expanded_real = real;
+	char expanded_real_buf[40];
 
 	#define MAX_DSN_HOST_LEN	64
 
@@ -291,10 +292,11 @@ STR crypt_userhost(CSTR real, HOST_TYPE htype, short int dotsCount) {
 
 	TRACE();
 	if (htype == htIPv6) {
-		len = str_len(expand_ipv6(real));
-	} else {
-		len = str_len(real);
+
+		expand_ipv6(real, expanded_real_buf, sizeof(expanded_real_buf));
+		expanded_real = expanded_real_buf;
 	}
+	len = str_len(expanded_real);
 	virlen = len + CRYPT_NETNAME_LEN + HIDEHOST_CHECKSUM_LEN + 2;
 
 	if (virlen > hidehost_buffer_size) {
@@ -305,11 +307,7 @@ STR crypt_userhost(CSTR real, HOST_TYPE htype, short int dotsCount) {
 
 	// generazione crypt
 
-	if (htype == htIPv6) {
-		hash = crypt_hash_SHA1(expand_ipv6(real), len, hidehost_crypt_buffer, hidehost_crypt_buffer_size);
-	} else {
-		hash = crypt_hash_SHA1(real, len, hidehost_crypt_buffer, hidehost_crypt_buffer_size);
-	}
+	hash = crypt_hash_SHA1(expanded_real, len, hidehost_crypt_buffer, hidehost_crypt_buffer_size);
 
 	// creazione stringa "criptata"
 
@@ -337,8 +335,6 @@ STR crypt_userhost(CSTR real, HOST_TYPE htype, short int dotsCount) {
 		struct in6_addr ip6addr;
 
 		char ip6buffer[INET6_ADDRSTRLEN];
-		strncpy(ip6buffer, expand_ipv6(real), sizeof(ip6buffer));
-
 		memset(ip6buffer, 0, sizeof(ip6buffer));
 		inet_pton(AF_INET6, real, &ip6addr);
 		memset(&(ip6addr.s6_addr[6]), 0, 10);

--- a/src/misc.c
+++ b/src/misc.c
@@ -2158,20 +2158,20 @@ HOST_TYPE host_type(CSTR host, short int *dotsCountPtr) {
  * compact form to its complete form.                    *
  *********************************************************/
 
-char *expand_ipv6(const char *input) {
+void expand_ipv6(CSTR input, STR output, size_t output_size) {
 
-	char output[40];
-	char *ptr = output;
+	char *ptr;
 	int i = 0, colons, len;
 
-	memcpy(ptr, "0000:0000:0000:0000:0000:0000:0000:0000", 40);
+	memcpy(output, "0000:0000:0000:0000:0000:0000:0000:0000", 40);
 
 	colons = str_count(input, ':');
 
 	if (colons > 7) {
-
 		LOG_DEBUG_SNOOP("Warning: IPv6 %s is invalid!", input);
-		return str_duplicate(input);
+		strncpy(output, input, output_size - 1);
+		output[output_size - 1] = '\0';
+		return;
 	}
 
 	len = strlen(input);
@@ -2208,8 +2208,6 @@ char *expand_ipv6(const char *input) {
 		input--;
 		len--;
 	}
-
-	return str_duplicate(output);
 }
 
 

--- a/src/operserv.c
+++ b/src/operserv.c
@@ -555,7 +555,7 @@ void check_clones_v6(const User *newUser) {
 	memset(clone_nicks, 0, sizeof(clone_nicks));
 	memset(tmp_clones, 0, sizeof(tmp_clones));
 	
-	strncpy(ipbuf, expand_ipv6(get_ip6(newUser->ipv6)), 42);
+	expand_ipv6(get_ip6(newUser->ipv6), ipbuf, sizeof(ipbuf));
 	idx = CONF_CLONE_SCAN_V6 * 5;
 	
 	ipbuf[idx++] = '*';
@@ -569,8 +569,7 @@ void check_clones_v6(const User *newUser) {
 		if (FlagUnset(userIPv6_item->user->flags, USER_FLAG_HAS_IPV6))
 			continue;
 
-		strncpy(ip_clonebuf, expand_ipv6(get_ip6(userIPv6_item->user->ipv6)), 42);
-		ip_clonebuf[41] = '\0';
+		expand_ipv6(get_ip6(userIPv6_item->user->ipv6), ip_clonebuf, sizeof(ip_clonebuf));
 
 		if (str_match_wild_nocase(ipbuf, ip_clonebuf)) {
 


### PR DESCRIPTION
The memory management semantics of `expand_ipv6()` weren't specified explicitly, so callers never bothered with free()'ing its return value.

This caused the IPv6 clone checker to leak memory like a sieve because the `expand_ipv6()` function would be called in a hot loop iterating over *every single IPv6 client*.

Fix this ugly behavior by getting rid of dynamic memory allocation altogether and making `expand_ipv6` take a caller-provided buffer to perform its work (some callers were copying its return value to an already existing buffer anyway...).