### PR TITLE
HelpServ: added cmode +z to help file

### DIFF
--- a/run/data/helpfiles/es/helpserv/cmode
+++ b/run/data/helpfiles/es/helpserv/cmode
@@ -21,4 +21,5 @@
   t  - Permite el cambio de topic del canal unicamente a los op's
   U  - Permite a los usuarios sin nick registrado en los robins .US y .EU entrar en un canal
   v  - Permite a los nicknames con +v escribir en un canal moderado (+m)
+  z  - Impide el acceso a una máscara (nick!user@host), excepto a los usuarios identificados
 *** Fin de la Lista ***

--- a/run/data/helpfiles/fr/helpserv/cmode
+++ b/run/data/helpfiles/fr/helpserv/cmode
@@ -22,4 +22,5 @@
   u  - Ne montre pas les messages de QUIT ou PART
   U  - Permet qu'aussi les usagers non-italiens pas identifiés aux nicks entrent dans le canal
   v  - Donne à un nick la permission de parler dans un canal modéré (+m)
+  z  - Empêche l'accès à un masque (nick!user@host), sauf pour les utilisateurs identifiés
 *** Fin de la liste ***

--- a/run/data/helpfiles/it/helpserv/cmode
+++ b/run/data/helpfiles/it/helpserv/cmode
@@ -22,4 +22,5 @@
   u  - Non mostra i messaggi di QUIT e PART di utenti del canale.
   U  - Permette agli utenti esteri non identificati di entrare nel canale.
   v  - Concede ad un nickname il permesso di parlare in un canale moderato (+m).
+  z  - Impedisce l'accesso a una mask (nick!user@host), salvo agli utenti identificati.
 *** Fine della Lista ***

--- a/run/data/helpfiles/us/helpserv/cmode
+++ b/run/data/helpfiles/us/helpserv/cmode
@@ -22,4 +22,5 @@
   u  - Blocks PART/QUIT messages sent to the channel.
   U  - Allow users without a registered nick on .US and .EU robins to join the channel. 
   v  - Gives voice to a nickname in the channel.
+  z  - Prevents access to a mask (nick!user@host), except for identified users.
 *** End of List ***


### PR DESCRIPTION
Added the missing HelpServ documentation for the +z channel mode across all languages.
Although this mode has been implemented in the ircd for several years, it was never officially documented or made public until now.