### PR TITLE
fix(operserv): match IPv6 address in OS FIND

### DIFF
--- a/src/operserv.c
+++ b/src/operserv.c
@@ -1140,7 +1140,9 @@ static void do_find(CSTR source, User *callerUser, ServiceCommandData *data) {
 				TRACE_MAIN();
 			#ifdef ENABLE_CAPAB_NICKIP
 				if ((nick ? str_match_wild(nick, user_nick) : 1 ) && str_match_wild(username, user_username) &&
-					(str_match_wild(host, user_host) || str_match_wild(host, user_xhost) || str_match_wild(host, str_tolower(get_ip(user->ip)))) )
+					(str_match_wild(host, user_host) || str_match_wild(host, user_xhost) ||
+					 str_match_wild(host, str_tolower(get_ip(user->ip))) ||
+					 str_match_wild(host, str_tolower(get_ip6(user->ipv6)))) )
 			#else
 				if ((nick ? str_match_wild(nick, user_nick) : 1 ) && str_match_wild(username, user_username) &&
 					(str_match_wild(host, user_host) || str_match_wild(host, user_xhost)))


### PR DESCRIPTION
## Summary

`OS FIND` only matched the host wildcard against `user->ip` (the IPv4 long-int), so v6 users were never returned. Live repro on the network: `OS F *@2a03:4000:2:33c:*` returned `End of search. Users found: 0.` while users were clearly connected on that prefix.

ChanServ already has the v6 branch in `do_akick` (`chanserv.c:2371`) via `get_ip6(user->ipv6)`. This patch applies the same against the OperServ FIND host disjunction, so masks like `*@2a03:4000:2:33c:*` now match IPv6-connected users.

The new branch lives inside `ENABLE_CAPAB_NICKIP` because `user->ipv6` only exists in that build path (see `inc/users.h:63-66`).

## Test plan
- [ ] Build with `ENABLE_CAPAB_NICKIP` (default)
- [ ] Connect a client via IPv6, e.g. `2a03:4000:2:33c::1`
- [ ] `OS F *@2a03:4000:2:33c:*` returns the client (previously: 0 found)
- [ ] `OS F *@<ipv4-mask>` still matches v4 users (regression check)
- [ ] Mask without `!` (i.e. `user@host`) still parses