### PR TITLE
fix(operserv): initialize position in check_clones_v6

### DIFF
--- a/src/operserv.c
+++ b/src/operserv.c
@@ -546,7 +546,7 @@ void check_clones_v6(const User *newUser) {
 	char			clone_nicks[220], ipbuf[42], ip_clonebuf[42], tmp_clones[220 - 4];
 	char			*reason;
 	BOOL    		more_clones = FALSE, sameHost = TRUE, nick_oper = FALSE, nick_exempt = FALSE, isExempt = FALSE, triggered = FALSE;
-	int			idx, warningIdx, cloneCount = 0, len = 0, position;
+	int			idx, warningIdx, cloneCount = 0, len = 0, position = 0;
 	User_AltListItem	*userIPv6_item = NULL;
 
 


### PR DESCRIPTION
## Problem

`check_clones_v6()` declares `position` without an initializer:

```c
int idx, warningIdx, cloneCount = 0, len = 0, position;
```

`check_clones()` (the v4 path) initializes it to `0`. `trigger_match()` writes through the `position` out-param **only** on the `triggerFound` branch (`trigger.c:477`, reached when `cloneCount > 0`); the `triggerExempt` and `triggerNotFound` returns leave `*position` untouched.

So on the exempt / no-match globops notice, the `[%d]` position field printed an uninitialized stack value — observed live as `32765` on one event and `0` on the next, for the same host.

## Fix

Initialize `position = 0`, matching `check_clones()`. The exempt/no-match notice now prints a stable `[0]` instead of stack garbage.

One-line change, compiles clean (`make -C src operserv.o`, no new warnings).

## Verification status (author)

Recorded explicitly so reviewers do not have to infer it:

- **Done:** compiles clean (`make -C src operserv.o`, no new warnings); the defect itself was
  observed live (the `[%d]` field printed `32765` on one clone-check globops and `0` on the next for
  the same host); the v4 sibling `check_clones()` was read and does initialize `position = 0`, so the
  fix restores parity rather than inventing behaviour.
- **Not done by me / not recorded:** no functional run on the testnet exercising an `OS TRIGGER`
  clone-check path with the patched binary. If such a run happened it was not written down, so it is
  not claimed here.

Blast radius, for the shipping decision: the only observable change is the value printed in the
`triggerExempt` / `triggerNotFound` globops notice. No matching, limit or enforcement logic is
touched — reading the uninitialised `position` was undefined behaviour, and the notice was printing
stack garbage.
