### PR TITLE
nickserv: match access list against masked host and IP, not just user->host

### DIFF
--- a/src/nickserv.c
+++ b/src/nickserv.c
@@ -1002,12 +1002,15 @@ BOOL is_on_access(const User *user, const NickInfo *ni) {
 	TRACE();
 	for (accessIdx = 0; (accessIdx < ni->accesscount); ++accessIdx) {
 
-		/* Match against the real host, the +x masked host and the (v4/v6) IP,
-		 * exactly like ChanServ akick/ban recognition does. The previous hand-rolled
+		/* Match against the real host and the (v4/v6) IP. The previous hand-rolled
 		 * "username@host" glob only ever looked at user->host, so an access mask
 		 * written against the IP address (e.g. an IPv6 prefix) never matched and the
-		 * user got guested even when correctly listed. */
-		if (user_usermask_match(ni->access[accessIdx], user, TRUE, TRUE))
+		 * user got guested even when correctly listed.
+		 * The +x masked host is deliberately not matched: the user always knows their
+		 * own plaintext host/IP, so there is nothing to gain from listing a cloak.
+		 * user_usermask_match() lacks support for IPv6 CIDR matching, so IPv6 access
+		 * entries work only with wildcard-based patterns; IPv4 CIDR is fully supported. */
+		if (user_usermask_match(ni->access[accessIdx], user, FALSE, TRUE))
 			return TRUE;
 	}
 

--- a/src/nickserv.c
+++ b/src/nickserv.c
@@ -983,9 +983,6 @@ NickInfo *retnick(int i) {
 /* Is the given user's address on the given nick's access list? Return 1 if so, 0 if not. */
 BOOL is_on_access(const User *user, const NickInfo *ni) {
 
-	size_t	len;
-	char	buffer[IRCBUFSIZE];
-	STR		ptr;
 	int		accessIdx;
 
 
@@ -1002,22 +999,15 @@ BOOL is_on_access(const User *user, const NickInfo *ni) {
 	if ((ni->accesscount == 0) || FlagSet(ni->flags, NI_SECURE))
 		return FALSE;
 
-	len = str_len(user->username);
-	memcpy(buffer, user->username, len);
-	ptr = buffer + len;
-
-	TRACE();
-	*(ptr++) = c_AT;
-	len = str_len(user->host);
-	memcpy(ptr, user->host, len);
-	ptr += len;
-
-	*ptr = c_NULL;
-
 	TRACE();
 	for (accessIdx = 0; (accessIdx < ni->accesscount); ++accessIdx) {
 
-		if (str_match_wild_nocase(ni->access[accessIdx], buffer))
+		/* Match against the real host, the +x masked host and the (v4/v6) IP,
+		 * exactly like ChanServ akick/ban recognition does. The previous hand-rolled
+		 * "username@host" glob only ever looked at user->host, so an access mask
+		 * written against the IP address (e.g. an IPv6 prefix) never matched and the
+		 * user got guested even when correctly listed. */
+		if (user_usermask_match(ni->access[accessIdx], user, TRUE, TRUE))
 			return TRUE;
 	}
 


### PR DESCRIPTION
## Problem

A NickServ access mask written against the connecting IP address — most importantly an IPv6 prefix such as `user@2a03:4000:2:33c*` — is accepted by `ACCESS ADD` but never recognises the user at signon: they get guested despite being correctly listed. Meanwhile ChanServ recognises the same user on the same connection.

## Root cause

`is_on_access()` hand-rolled a `username@host` string and glob-matched it **only** against `user->host`. Services hold the binary IP in `user->ipv6` / `user->ip`, which this path never consulted, so an IP/prefix-based access mask had nothing to match against.

ChanServ akick/ban recognition (`chanserv.c`) already does the right thing via `user_usermask_match()`, which matches the real host and the v4/v6 IP (`get_ip6(user->ipv6)`). The two recognise paths simply used different matchers — one complete, one not.

## Fix

Delegate `is_on_access()` to `user_usermask_match(mask, user, FALSE, TRUE)`. IP-based and IPv6-prefix access masks now resolve as expected.

- The `+x` masked host is deliberately **not** matched (`matchMaskedHost` is `FALSE`): the user always knows their own plaintext host/IP, so listing a cloak buys nothing.
- `user_usermask_match()` has no IPv6 CIDR support — the `matchCIDR` leg wildcard-matches `get_ip6()` for v6 and only runs `cidr_match()` against `user->ip` (v4). IPv6 access entries therefore work with wildcard patterns only; IPv4 CIDR masks are matched in full. Adding IPv6 CIDR matching is out of scope here.
- No on-disk format change; existing host-based masks keep working (the real-host leg still runs first).
- The manual buffer build is gone.
- `NI_SECURE` short-circuit and the empty-list guard are unchanged.

Reported on #it-opers (Mezmerize repro: `mezmerize@2a03:4000:2:33c*` accepted but guested; IPv6 connection, no `+x`).
