### PR TITLE
Fix varargs shenanigans

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,43 @@ jobs:
           path: src/services
           retention-days: 7
 
+  build32:
+    name: build with forced ILP32 (${{ matrix.container }})
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - debian:trixie
+          - debian:bookworm
+          - ubuntu:24.04
+
+    steps:
+      - name: install build deps
+        run: |
+          dpkg --add-architecture i386
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential libc6-dev ca-certificates git python3 \
+            gcc-multilib g++-multilib libc6-dev:i386
+
+      - uses: actions/checkout@v4
+
+      - name: compile language files
+        run: python3 lang/langcomp.py
+
+      - name: configure
+        run: ./configure -m32
+
+      - name: build
+        run: make
+
+      - name: verify binary
+        run: |
+          test -x ./src/services
+          ls -la ./src/services
+
   docker:
     name: docker build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Makefile.inc
 *.swp
 *.o
 lang/__pycache__/
+/.vscode/**

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Makefile.inc
 *.o
 lang/__pycache__/
 /.vscode/**
+/.idea/**

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Makefile.inc
 lang/__pycache__/
 /.vscode/**
 /.idea/**
+/tmp/**

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 RM=/bin/rm
 
 # Compile flags
-CFLAGS += -pipe -Wall -O0 -g -Wshadow -Wcast-align -Wsign-compare -Wformat -Wformat-signedness -Wformat-security -Werror=format -Werror=format-security
+CFLAGS += -pipe -Wall -Wpedantic -O0 -g -Wshadow -Wcast-align -Wsign-compare -Wformat -Wformat-signedness -Wformat-security -Werror=format -Werror=format-security
 # linker flags.
 LDFLAGS=
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 RM=/bin/rm
 
 # Compile flags
-CFLAGS += -pipe -Wall -O0 -g -Wshadow -Wcast-align -Wsign-compare
+CFLAGS += -pipe -Wall -O0 -g -Wshadow -Wcast-align -Wsign-compare -Wformat -Wformat-signedness -Werror=format
 # linker flags.
 LDFLAGS=
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build: inc/sysconf.h $(SUBDIRS)
 inc/sysconf.h:
 	@$(SHELL) configure
 
-$(SUBDIRS):
+$(SUBDIRS): | inc/sysconf.h
 	$(MAKE) -C $@
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -26,23 +26,17 @@ LDFLAGS=
 
 SHELL=/bin/sh
 SUBDIRS=src
-
-MAKE=make 'CFLAGS=${CFLAGS}' 'INSTALL=${INSTALL}' 'LDFLAGS=${LDFLAGS}'
+MAKE=make 'CFLAGS=${CFLAGS}' 'LDFLAGS=${LDFLAGS}'
 
 all:	build
 
-build:
-	-@if [ ! -f inc/sysconf.h ] ; then \
-		echo "Hmm... doesn't look like you've run configure..."; \
-		echo "Doing so now."; \
-		sh configure; \
-	fi
-	@for i in $(SUBDIRS); do \
-		echo "Building $$i";\
-		cd $$i;\
-		${MAKE} build; cd ..;\
-	done
-	@echo "All done!"
+build: inc/sysconf.h $(SUBDIRS)
+
+inc/sysconf.h:
+	@$(SHELL) configure
+
+$(SUBDIRS):
+	$(MAKE) -C $@
 
 clean:
 	@${RM} -f services
@@ -55,3 +49,5 @@ distclean:
 	@${RM} -f Makefile.inc configure.log services
 	@cd inc; ${RM} -f sysconf.h; cd ..
 	@cd src; ${RM} -f *.o services; cd ..
+
+.PHONY: all build clean distclean $(SUBDIRS)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 RM=/bin/rm
 
 # Compile flags
-CFLAGS += -pipe -Wall -O0 -g -Wshadow -Wcast-align -Wsign-compare -Wformat -Wformat-signedness -Werror=format
+CFLAGS += -pipe -Wall -O0 -g -Wshadow -Wcast-align -Wsign-compare -Wformat -Wformat-signedness -Wformat-security -Werror=format -Werror=format-security
 # linker flags.
 LDFLAGS=
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@
 RM=/bin/rm
 
 # Compile flags
-CFLAGS += -pipe -Wall -Wpedantic -O0 -g -Wshadow -Wcast-align -Wsign-compare -Wformat -Wformat-signedness -Wformat-security -Werror=format -Werror=format-security
+CFLAGS = $(BASE_CFLAGS)
+CFLAGS += -pipe -Wall -Wpedantic -g -Wshadow -Wcast-align -Wsign-compare -Wformat -Wformat-signedness -Wformat-security -Werror=format -Werror=format-security
 # linker flags.
 LDFLAGS=
 

--- a/configure
+++ b/configure
@@ -121,7 +121,7 @@ DATDEST=./data
 CC=
 CC_LIBS=
 CC_FLAGS=bonkle
-CC_LFLAGS=bonkle
+CC_LFLAGS=
 
 OSTYPE=bonkle
 
@@ -261,6 +261,7 @@ echo 'Forcing ILP32 build, DO NOT DO THIS IN PRODUCTION UNLESS YOU KNOW EXACTLY 
 echo '********************************************************************************************'
 LBIT=32
 DEF_CC_FLAGS="-m32 $DEF_CC_FLAGS"
+CC_LFLAGS="-m32"
 else
 LBIT=$(getconf LONG_BIT)
 fi
@@ -300,7 +301,6 @@ if [ "$USER_CC_LFLAGS" != "bonkle" ] ; then
 	log user supplied \`"$CC_LFLAGS'"
 else
 	log using no flags
-	CC_LFLAGS=""
 fi
 
 ###########################################################################

--- a/configure
+++ b/configure
@@ -429,6 +429,7 @@ fi
 # Create files.
 
 echo2 "Creating sysconf.h... "
+LBIT=$(getconf LONG_BIT)
 cat >inc/sysconf.h <<EOT
 /*
  * This file is generated automatically by "configure".  Any changes made
@@ -437,6 +438,8 @@ cat >inc/sysconf.h <<EOT
 
 #define SERVICES_BIN		"$BINDEST/services"
 #define SERVICES_DIR		"$DATDEST"
+
+#define OS_${LBIT}BIT
 
 EOT
 
@@ -465,7 +468,6 @@ fi
 echo "done."
 
 echo2 "Creating Makefile.inc... "
-LBIT=$(getconf LONG_BIT)
 cat >Makefile.inc <<EOT
 # This file is generated automatically by "configure".  Any changes made
 # to it will be erased next time "configure" is run.
@@ -478,8 +480,6 @@ LIBS=$CC_LIBS
 PROGRAM=services
 BINDEST=$BINDEST
 DATDEST=$DATDEST
-LBIT=$LBIT
-CFLAGS += -DOS_${LBIT}BIT
 
 EOT
 echo "done."

--- a/configure
+++ b/configure
@@ -271,6 +271,9 @@ fi
 MODE="find_ccopts     "
 if [ "$USER_CC_FLAGS" != bonkle ] ; then
 	CC_FLAGS="$USER_CC_FLAGS"
+	if [ "x$FORCE_M32" = 'xyes' ]; then
+		CC_FLAGS="-m32 $CC_FLAGS"
+	fi
 	echo "Compiler flags supplied: $CC_FLAGS"
 	log user supplied flags: \`"$CC_FLAGS'"
 else

--- a/configure
+++ b/configure
@@ -80,7 +80,7 @@ test_function () {
     #include <stdio.h>
     #include <string.h>
 	int main() {
-		extern int $func$proto;
+		extern $rettype $func$proto;
 		$TEST
 	}
 EOT
@@ -156,6 +156,7 @@ USER_CC=
 USER_CC_FLAGS=bonkle
 USER_CC_LFLAGS=bonkle
 USER_CC_LIBS=
+FORCE_M32=no
 
 export USER_CC USER_CC_FLAGS USER_CC_LFLAGS USER_CC_LIBS
 
@@ -172,6 +173,8 @@ while [ $# -gt 0 ] ; do
 	elif [ "$1" = "-libs" ] ; then
 		shift
 		USER_CC_LIBS=$1
+	elif [ "$1" = "-m32" ] ; then
+		FORCE_M32=yes
 	else
 		if [ "$1" != "-help" -a "$1" != "-h" -a "$1" != "--help" ]; then
 			echo >&2 Unknown option/parameter: "$1"
@@ -181,11 +184,12 @@ while [ $# -gt 0 ] ; do
 		fi
 		cat >&2 <<EOT
 Available options:
-	-cc			Specify C compiler to use (overrides check)
-	-cflags		Specify compilation flags (defaults: -O2 for gcc,
-			    -O for other compilers; overrides check)
-	-lflags		Specify link flags for C compiler (default: none)
-	-libs		Specify extra link libraries to use (default: none)
+    -cc     Specify C compiler to use (overrides check)
+    -cflags Specify compilation flags (defaults: -O2 for gcc,
+            -O for other compilers; overrides check)
+    -lflags Specify link flags for C compiler (default: none)
+    -libs   Specify extra link libraries to use (default: none)
+    -m32    Force ILP32 build on LP64 systems (DANGEROUS, use with care!)
 EOT
 		exit $exitval
 	fi
@@ -216,7 +220,7 @@ if [ "$USER_CC" ] ; then
 elif run gcc --version ; then
 	echo "great, found gcc!"
 	CC=gcc
-	DEF_CC_FLAGS=-O2
+	DEF_CC_FLAGS=-O0
 	log using \`gcc\'
 else
 	echo "gcc not found."
@@ -251,6 +255,15 @@ EOT
 	DEF_CC_FLAGS=-O
 fi
 
+if [ "x$FORCE_M32" = "xyes" ]; then
+echo '************************************** /!\ DANGER /!\ **************************************'
+echo 'Forcing ILP32 build, DO NOT DO THIS IN PRODUCTION UNLESS YOU KNOW EXACTLY WHAT YOU ARE DOING'
+echo '********************************************************************************************'
+LBIT=32
+DEF_CC_FLAGS="-m32 $DEF_CC_FLAGS"
+else
+LBIT=$(getconf LONG_BIT)
+fi
 
 # Test compiler options.
 
@@ -394,7 +407,7 @@ TEST='
 	}
 
 	return 0;'
-if test_function int snprintf "(char *, long unsigned int, const char *, ...)" ; then : ; else
+if test_function int snprintf "(char *, size_t, const char *, ...)" ; then : ; else
 	echo2 "snprintf "
 	echo ""
 	echo "Your snprintf() is not compatible with services' needs."
@@ -429,7 +442,6 @@ fi
 # Create files.
 
 echo2 "Creating sysconf.h... "
-LBIT=$(getconf LONG_BIT)
 cat >inc/sysconf.h <<EOT
 /*
  * This file is generated automatically by "configure".  Any changes made

--- a/configure
+++ b/configure
@@ -301,6 +301,9 @@ fi
 MODE="find_lflags     "
 if [ "$USER_CC_LFLAGS" != "bonkle" ] ; then
 	CC_LFLAGS=$USER_CC_LFLAGS
+	if [ "x$FORCE_M32" = 'xyes' ]; then
+		CC_LFLAGS="-m32 $CC_LFLAGS"
+	fi
 	log user supplied \`"$CC_LFLAGS'"
 else
 	log using no flags

--- a/inc/common.h
+++ b/inc/common.h
@@ -36,6 +36,7 @@
 #include <sys/time.h>
 #include <ctype.h>
 #include <fcntl.h>
+#include <inttypes.h>
 
 /* Services headers */
 #include "xrefs.h"

--- a/inc/logging.h
+++ b/inc/logging.h
@@ -145,28 +145,11 @@ extern time_t log_next_midnight_time;
  * Macros                                                *
  *********************************************************/
 
-#define LOG_DEBUG(fmt, ...) \
-	do { \
-		if ((CONF_SET_DEBUG == TRUE) && IS_NOT_NULL(fmt) && (log_rotation_started == FALSE)) \
-			log_debug((fmt) , ##__VA_ARGS__); \
-	} while (0)
-
-#define LOG_SNOOP(agent, fmt, ...) \
-	do { \
-		if ((global_running == TRUE) && (CONF_SET_SNOOP == TRUE) && IS_NOT_NULL(fmt)) \
-			log_snoop((agent), (fmt) , ##__VA_ARGS__); \
-	} while (0)
-
-#define LOG_DEBUG_SNOOP(fmt, ...) \
-	do { \
-		if ((global_running == TRUE) && (CONF_SET_SNOOP == TRUE) && IS_NOT_NULL(fmt)) \
-			log_debug_snoop((fmt) , ##__VA_ARGS__); \
-	} while (0)
-
-#define LOG_PROXY(agent, fmt, ...) \
-	do { \
-		if ((global_running == TRUE) && (CONF_SET_SNOOP == TRUE) && IS_NOT_NULL(fmt)) \
-			log_proxy((agent), (fmt) , ##__VA_ARGS__); \
-	} while (0)
+ /* TODO: for backward compatibility only, replace uppercase variants with lowercase ones
+  * only after everything is working (LOG_SNOOP alone has 700+ callsites across the codebase!)
+  */
+#define LOG_DEBUG log_debug
+#define LOG_SNOOP log_snoop
+#define LOG_DEBUG_SNOOP log_debug_snoop
 
 #endif /* SRV_LOGGING_H */

--- a/inc/logging.h
+++ b/inc/logging.h
@@ -99,32 +99,32 @@ extern void log_done(void);
 extern void log_rotate(BOOL force);
 
 /* Log errors on the errors log file (errors.log) and on the debug-snoop channel (default is #bugs) */
-extern void log_error(FACILITY facility, FACILITY_LINE subcode, LOG_TYPE type, SEVERITY severity, CSTR fmt, ...);
+extern void log_error(FACILITY facility, FACILITY_LINE subcode, LOG_TYPE type, SEVERITY severity, CSTR fmt, ...) ATTRIBUTE_PRINTF(5, 6);
 
 /* Log debug messages on the debug log file (debugs.log) */
-extern void log_debug(CSTR fmt, ...);
+extern void log_debug(CSTR fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 extern void log_debug_direct(CSTR string);
 
 extern int logid_from_agentid(agentid_t agentID);
 
 /* Log service messages on the services log file (services.log) */
-extern void log_services(int services, CSTR fmt, ...);
+extern void log_services(int services, CSTR fmt, ...) ATTRIBUTE_PRINTF(2, 3);
 
 /* Log panic messages on the panic error log file (panic.log) */
-extern void log_panic(CSTR fmt, ...);
+extern void log_panic(CSTR fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 extern void log_panic_direct(CSTR string);
 
 /* Send message to the services snoop channel (default is #security) */
-extern void log_snoop(CSTR source, CSTR fmt, ...);
+extern void log_snoop(CSTR source, CSTR fmt, ...) ATTRIBUTE_PRINTF(2, 3);
 
 /* Send message to the debug snoop channel (default is #bugs) */
-extern void log_debug_snoop(CSTR fmt, ...);
+extern void log_debug_snoop(CSTR fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 
 /* Send the libc error message on the debug snoop channel and on the stderr stream */
-extern void log_stderr(CSTR fmt, ...);
+extern void log_stderr(CSTR fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 
 /* Log the error both on the log file and on the stderr stream, send a globops, then die. */
-extern void fatal_error(FACILITY facility, FACILITY_LINE line, CSTR fmt, ...);
+extern void fatal_error(FACILITY facility, FACILITY_LINE line, CSTR fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 
 extern CSTR log_get_day_timestamp(int day, int month, int year);
 extern CSTR log_get_timestamp(time_t logtime);

--- a/inc/macros.h
+++ b/inc/macros.h
@@ -116,5 +116,13 @@ typedef	unsigned int			result_t;
 		len += str_copy_checked((string), (buffer + len), (sizeof(buffer) - len)); \
 	}
 
+#ifndef ATTRIBUTE_PRINTF
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define ATTRIBUTE_PRINTF(fnum, anum) __attribute__((nonnull(fnum))) \
+    __attribute__((__format__(__printf__, fnum, anum)))
+#else
+#define ATTRIBUTE_PRINTF(format, arg)
+#endif /* defined(__GNUC__) && __GNUC__ >= 4 */
+#endif /* ATTRIBUTE_PRINTF */
 
 #endif /* SRV_MACROS_H */

--- a/inc/send.h
+++ b/inc/send.h
@@ -38,7 +38,7 @@ extern void send_cmd(CSTR fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 extern void send_globops(CSTR source, CSTR fmt, ...) ATTRIBUTE_PRINTF(2, 3);
 extern void send_chatops(CSTR source, CSTR fmt, ...) ATTRIBUTE_PRINTF(2, 3);
 extern void send_SPAMOPS(CSTR source, CSTR fmt, ...) ATTRIBUTE_PRINTF(2, 3);
-extern void send_PRIVMSG(CSTR source, CSTR dest, CSTR fmt, ...);
+extern void send_PRIVMSG(CSTR source, CSTR dest, CSTR fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 extern void send_NICK(CSTR nickname, CSTR umode, CSTR username, CSTR hostname, CSTR realname);
 extern void send_KILL(CSTR source, CSTR who, CSTR reason, BOOL killUser);
 extern void send_AKILL(CSTR username, CSTR host, CSTR who, CSTR reason, const unsigned long int id, CSTR type);
@@ -53,9 +53,10 @@ extern void send_SVSNOOP(CSTR server, char action);
 extern void send_SVSNICK(CSTR nick, CSTR newnick);
 extern void send_SHUN(CSTR source, CSTR target, CSTR reason);
 
-extern void send_notice_to_nick(CSTR source, CSTR dest, CSTR fmt, ...);
-extern void send_notice_to_user(CSTR source, const User *dest, CSTR fmt, ...);
+extern void send_notice_to_nick(CSTR source, CSTR dest, CSTR fmt, ...) ATTRIBUTE_PRINTF(3, 4);
+extern void send_notice_to_user(CSTR source, const User *dest, CSTR fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 
+/* TODO: these are going to escape GCC format string diagnostics, remove them if/when we replace the lang subsystem with gettext */
 extern void send_notice_lang_to_nick(CSTR source, CSTR dest, const LANG_ID lang_id, const LANG_MSG_ID msg_id, ...);
 extern void send_notice_lang_to_user(CSTR source, const User *dest, const LANG_ID lang_id, const LANG_MSG_ID msg_id, ...);
 

--- a/inc/send.h
+++ b/inc/send.h
@@ -7,7 +7,7 @@
 * details.
 *
 * send.h - Routines for sending stuff to the network
-* 
+*
 */
 
 
@@ -33,11 +33,11 @@ extern unsigned long int total_sendM;
  * Public code                                           *
  *********************************************************/
 
-extern void send_cmd(CSTR fmt, ...);
+extern void send_cmd(CSTR fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 
-extern void send_globops(CSTR source, CSTR fmt, ...);
-extern void send_chatops(CSTR source, CSTR fmt, ...);
-extern void send_SPAMOPS(CSTR source, CSTR fmt, ...);
+extern void send_globops(CSTR source, CSTR fmt, ...) ATTRIBUTE_PRINTF(2, 3);
+extern void send_chatops(CSTR source, CSTR fmt, ...) ATTRIBUTE_PRINTF(2, 3);
+extern void send_SPAMOPS(CSTR source, CSTR fmt, ...) ATTRIBUTE_PRINTF(2, 3);
 extern void send_PRIVMSG(CSTR source, CSTR dest, CSTR fmt, ...);
 extern void send_NICK(CSTR nickname, CSTR umode, CSTR username, CSTR hostname, CSTR realname);
 extern void send_KILL(CSTR source, CSTR who, CSTR reason, BOOL killUser);

--- a/src/access.c
+++ b/src/access.c
@@ -572,7 +572,7 @@ void access_send_dump(Access *anAccess, CSTR sourceNick, const User *callerUser)
 	send_notice_to_user(sourceNick, callerUser, "Modes ON: %ld \2[\2%s\2]\2",	anAccess->modes_on, get_user_modes(anAccess->modes_on, 0));
 	send_notice_to_user(sourceNick, callerUser, "Modes OFF: %ld \2[\2%s\2]\2",	anAccess->modes_off, get_user_modes(0, anAccess->modes_off));
 
-	send_notice_to_user(sourceNick, callerUser, "Created by: %p \2[\2%s\2]\2",	anAccess->creator.name, str_get_valid_display_value(anAccess->creator.name));
+	send_notice_to_user(sourceNick, callerUser, "Created by: %p \2[\2%s\2]\2",	(void *)anAccess->creator.name, str_get_valid_display_value(anAccess->creator.name));
 	send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",		anAccess->creator.time);
 	send_notice_to_user(sourceNick, callerUser, "Last Update C-time: %ld",		anAccess->lastUpdate);
 	send_notice_to_user(sourceNick, callerUser, "Next record: %p",				(void *)anAccess->next);

--- a/src/access.c
+++ b/src/access.c
@@ -556,17 +556,17 @@ BOOL send_access_info(Access *accessList, CSTR nick, CSTR sourceNick, const User
 
 void access_send_dump(Access *anAccess, CSTR sourceNick, const User *callerUser) {
 
-	send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",		anAccess, sizeof(Access));
-	send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",		anAccess->nick, str_get_valid_display_value(anAccess->nick));
-	send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		anAccess->user, str_get_valid_display_value(anAccess->user));
-	send_notice_to_user(sourceNick, callerUser, "User2: %p \2[\2%s\2]\2",		anAccess->user2, str_get_valid_display_value(anAccess->user2));
-	send_notice_to_user(sourceNick, callerUser, "User3: %p \2[\2%s\2]\2",		anAccess->user3, str_get_valid_display_value(anAccess->user3));
-	send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		anAccess->host, str_get_valid_display_value(anAccess->host));
-	send_notice_to_user(sourceNick, callerUser, "Host2: %p \2[\2%s\2]\2",		anAccess->host2, str_get_valid_display_value(anAccess->host2));
-	send_notice_to_user(sourceNick, callerUser, "Host3: %p \2[\2%s\2]\2",		anAccess->host3, str_get_valid_display_value(anAccess->host3));
-	send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",		anAccess->server, str_get_valid_display_value(anAccess->server));
-	send_notice_to_user(sourceNick, callerUser, "Server2: %p \2[\2%s\2]\2",		anAccess->server2, str_get_valid_display_value(anAccess->server2));
-	send_notice_to_user(sourceNick, callerUser, "Server3: %p \2[\2%s\2]\2",		anAccess->server3, str_get_valid_display_value(anAccess->server3));
+	send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",		(void *)anAccess, sizeof(Access));
+	send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",		(void *)anAccess->nick, str_get_valid_display_value(anAccess->nick));
+	send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		(void *)anAccess->user, str_get_valid_display_value(anAccess->user));
+	send_notice_to_user(sourceNick, callerUser, "User2: %p \2[\2%s\2]\2",		(void *)anAccess->user2, str_get_valid_display_value(anAccess->user2));
+	send_notice_to_user(sourceNick, callerUser, "User3: %p \2[\2%s\2]\2",		(void *)anAccess->user3, str_get_valid_display_value(anAccess->user3));
+	send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		(void *)anAccess->host, str_get_valid_display_value(anAccess->host));
+	send_notice_to_user(sourceNick, callerUser, "Host2: %p \2[\2%s\2]\2",		(void *)anAccess->host2, str_get_valid_display_value(anAccess->host2));
+	send_notice_to_user(sourceNick, callerUser, "Host3: %p \2[\2%s\2]\2",		(void *)anAccess->host3, str_get_valid_display_value(anAccess->host3));
+	send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",		(void *)anAccess->server, str_get_valid_display_value(anAccess->server));
+	send_notice_to_user(sourceNick, callerUser, "Server2: %p \2[\2%s\2]\2",		(void *)anAccess->server2, str_get_valid_display_value(anAccess->server2));
+	send_notice_to_user(sourceNick, callerUser, "Server3: %p \2[\2%s\2]\2",		(void *)anAccess->server3, str_get_valid_display_value(anAccess->server3));
 	send_notice_to_user(sourceNick, callerUser, "Flags: %ld",					anAccess->flags);
 
 	send_notice_to_user(sourceNick, callerUser, "Modes ON: %ld \2[\2%s\2]\2",	anAccess->modes_on, get_user_modes(anAccess->modes_on, 0));
@@ -575,7 +575,7 @@ void access_send_dump(Access *anAccess, CSTR sourceNick, const User *callerUser)
 	send_notice_to_user(sourceNick, callerUser, "Created by: %p \2[\2%s\2]\2",	anAccess->creator.name, str_get_valid_display_value(anAccess->creator.name));
 	send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",		anAccess->creator.time);
 	send_notice_to_user(sourceNick, callerUser, "Last Update C-time: %ld",		anAccess->lastUpdate);
-	send_notice_to_user(sourceNick, callerUser, "Next record: %p",				anAccess->next);
+	send_notice_to_user(sourceNick, callerUser, "Next record: %p",				(void *)anAccess->next);
 }
 
 /*********************************************************/

--- a/src/access.c
+++ b/src/access.c
@@ -556,7 +556,7 @@ BOOL send_access_info(Access *accessList, CSTR nick, CSTR sourceNick, const User
 
 void access_send_dump(Access *anAccess, CSTR sourceNick, const User *callerUser) {
 
-	send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",		(void *)anAccess, sizeof(Access));
+	send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",		(void *)anAccess, sizeof(Access));
 	send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",		(void *)anAccess->nick, str_get_valid_display_value(anAccess->nick));
 	send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		(void *)anAccess->user, str_get_valid_display_value(anAccess->user));
 	send_notice_to_user(sourceNick, callerUser, "User2: %p \2[\2%s\2]\2",		(void *)anAccess->user2, str_get_valid_display_value(anAccess->user2));

--- a/src/access.c
+++ b/src/access.c
@@ -556,26 +556,26 @@ BOOL send_access_info(Access *accessList, CSTR nick, CSTR sourceNick, const User
 
 void access_send_dump(Access *anAccess, CSTR sourceNick, const User *callerUser) {
 
-	send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",		(unsigned long)anAccess, sizeof(Access));
-	send_notice_to_user(sourceNick, callerUser, "Nick: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->nick, str_get_valid_display_value(anAccess->nick));
-	send_notice_to_user(sourceNick, callerUser, "User: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->user, str_get_valid_display_value(anAccess->user));
-	send_notice_to_user(sourceNick, callerUser, "User2: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->user2, str_get_valid_display_value(anAccess->user2));
-	send_notice_to_user(sourceNick, callerUser, "User3: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->user3, str_get_valid_display_value(anAccess->user3));
-	send_notice_to_user(sourceNick, callerUser, "Host: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->host, str_get_valid_display_value(anAccess->host));
-	send_notice_to_user(sourceNick, callerUser, "Host2: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->host2, str_get_valid_display_value(anAccess->host2));
-	send_notice_to_user(sourceNick, callerUser, "Host3: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->host3, str_get_valid_display_value(anAccess->host3));
-	send_notice_to_user(sourceNick, callerUser, "Server: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->server, str_get_valid_display_value(anAccess->server));
-	send_notice_to_user(sourceNick, callerUser, "Server2: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->server2, str_get_valid_display_value(anAccess->server2));
-	send_notice_to_user(sourceNick, callerUser, "Server3: 0x%08X \2[\2%s\2]\2",		(unsigned long)anAccess->server3, str_get_valid_display_value(anAccess->server3));
-	send_notice_to_user(sourceNick, callerUser, "Flags: %ld",						anAccess->flags);
+	send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",		anAccess, sizeof(Access));
+	send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",		anAccess->nick, str_get_valid_display_value(anAccess->nick));
+	send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		anAccess->user, str_get_valid_display_value(anAccess->user));
+	send_notice_to_user(sourceNick, callerUser, "User2: %p \2[\2%s\2]\2",		anAccess->user2, str_get_valid_display_value(anAccess->user2));
+	send_notice_to_user(sourceNick, callerUser, "User3: %p \2[\2%s\2]\2",		anAccess->user3, str_get_valid_display_value(anAccess->user3));
+	send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		anAccess->host, str_get_valid_display_value(anAccess->host));
+	send_notice_to_user(sourceNick, callerUser, "Host2: %p \2[\2%s\2]\2",		anAccess->host2, str_get_valid_display_value(anAccess->host2));
+	send_notice_to_user(sourceNick, callerUser, "Host3: %p \2[\2%s\2]\2",		anAccess->host3, str_get_valid_display_value(anAccess->host3));
+	send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",		anAccess->server, str_get_valid_display_value(anAccess->server));
+	send_notice_to_user(sourceNick, callerUser, "Server2: %p \2[\2%s\2]\2",		anAccess->server2, str_get_valid_display_value(anAccess->server2));
+	send_notice_to_user(sourceNick, callerUser, "Server3: %p \2[\2%s\2]\2",		anAccess->server3, str_get_valid_display_value(anAccess->server3));
+	send_notice_to_user(sourceNick, callerUser, "Flags: %ld",					anAccess->flags);
 
-	send_notice_to_user(sourceNick, callerUser, "Modes ON: %ld \2[\2%s\2]\2",		anAccess->modes_on, get_user_modes(anAccess->modes_on, 0));
-	send_notice_to_user(sourceNick, callerUser, "Modes OFF: %ld \2[\2%s\2]\2",		anAccess->modes_off, get_user_modes(0, anAccess->modes_off));
+	send_notice_to_user(sourceNick, callerUser, "Modes ON: %ld \2[\2%s\2]\2",	anAccess->modes_on, get_user_modes(anAccess->modes_on, 0));
+	send_notice_to_user(sourceNick, callerUser, "Modes OFF: %ld \2[\2%s\2]\2",	anAccess->modes_off, get_user_modes(0, anAccess->modes_off));
 
-	send_notice_to_user(sourceNick, callerUser, "Created by: 0x%08X \2[\2%s\2]\2",	(unsigned long)anAccess->creator.name, str_get_valid_display_value(anAccess->creator.name));
-	send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",			anAccess->creator.time);
-	send_notice_to_user(sourceNick, callerUser, "Last Update C-time: %ld",			anAccess->lastUpdate);
-	send_notice_to_user(sourceNick, callerUser, "Next record: 0x%08X",				(unsigned long)anAccess->next);
+	send_notice_to_user(sourceNick, callerUser, "Created by: %p \2[\2%s\2]\2",	anAccess->creator.name, str_get_valid_display_value(anAccess->creator.name));
+	send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",		anAccess->creator.time);
+	send_notice_to_user(sourceNick, callerUser, "Last Update C-time: %ld",		anAccess->lastUpdate);
+	send_notice_to_user(sourceNick, callerUser, "Next record: %p",				anAccess->next);
 }
 
 /*********************************************************/

--- a/src/akill.c
+++ b/src/akill.c
@@ -1324,7 +1324,7 @@ void akill_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 						send_notice_to_user(sourceNick, callerUser, "Expiry C-time: %ld",			akill->expireTime);
 						send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		akill->lastUsed);
 						send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)akill->reason, str_get_valid_display_value(akill->reason));
-						send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",	akill->desc, str_get_valid_display_value(akill->desc));
+						send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",	(void *)akill->desc, str_get_valid_display_value(akill->desc));
 						send_notice_to_user(sourceNick, callerUser, "Type: %#lx \2[\2%s\2]\2",		akill->type, get_akill_type_long(akill->type));
 						send_notice_to_user(sourceNick, callerUser, "ID: %lu-%s",					akill->id, get_akill_type_short(akill->type));
 						send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	(void *)akill->next, (void *)akill->prev);

--- a/src/akill.c
+++ b/src/akill.c
@@ -147,6 +147,7 @@ BOOL akill_db_load(void) {
 									break;
 
 								case stgSuccess: // a valid record
+#ifdef OS_64BIT
 									if (!is64Bit) {
 										akill->creator.name = (STR)(uintptr_t) akill32.creator.name;
 										akill->creator.time = akill32.creator.time;
@@ -160,6 +161,7 @@ BOOL akill_db_load(void) {
 										akill->id = akill32.id;
 										akill->type = akill32.type;
 									}
+#endif
 									read_done = TRUE;
 
 									if (akill->username)
@@ -791,7 +793,7 @@ void handle_akill(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(reason)) > 220) {
 
-			send_notice_to_user(data->agent->nick, callerUser, "Reason cannot be longer than 220 characters (yours has: %lu).", len);
+			send_notice_to_user(data->agent->nick, callerUser, "Reason cannot be longer than 220 characters (yours has: %zu).", len);
 			return;
 		}
 
@@ -1313,7 +1315,7 @@ void akill_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					if (str_match_wild_nocase(user, akill->username) &&
 						str_match_wild_nocase(host, akill->host)) {
 
-						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	akillIdx, (void *)akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason));
+						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",	akillIdx, (void *)akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason));
 						send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		(void *)akill->username, str_get_valid_display_value(akill->username));
 						send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		(void *)akill->host, str_get_valid_display_value(akill->host));
 						send_notice_to_user(sourceNick, callerUser, "CIDR: %u/%u",					akill->cidr.ip, akill->cidr.mask);
@@ -1358,7 +1360,7 @@ void akill_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 								++akillIdx;
 
-								send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	akillIdx, (void *)akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason) + 4);
+								send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",	akillIdx, (void *)akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason) + 4);
 								send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		(void *)akill->username, str_get_valid_display_value(akill->username));
 								send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		(void *)akill->host, str_get_valid_display_value(akill->host));
 								send_notice_to_user(sourceNick, callerUser, "CIDR: %u/%u",					akill->cidr.ip, akill->cidr.mask);

--- a/src/akill.c
+++ b/src/akill.c
@@ -1313,19 +1313,19 @@ void akill_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					if (str_match_wild_nocase(user, akill->username) &&
 						str_match_wild_nocase(host, akill->host)) {
 
-						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	akillIdx, akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason));
-						send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		akill->username, str_get_valid_display_value(akill->username));
-						send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		akill->host, str_get_valid_display_value(akill->host));
+						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	akillIdx, (void *)akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason));
+						send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		(void *)akill->username, str_get_valid_display_value(akill->username));
+						send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		(void *)akill->host, str_get_valid_display_value(akill->host));
 						send_notice_to_user(sourceNick, callerUser, "CIDR: %u/%u",					akill->cidr.ip, akill->cidr.mask);
-						send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		akill->creator.name, str_get_valid_display_value(akill->creator.name));
+						send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		(void *)akill->creator.name, str_get_valid_display_value(akill->creator.name));
 						send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			akill->creator.time);
 						send_notice_to_user(sourceNick, callerUser, "Expiry C-time: %ld",			akill->expireTime);
 						send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		akill->lastUsed);
-						send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		akill->reason, str_get_valid_display_value(akill->reason));
+						send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)akill->reason, str_get_valid_display_value(akill->reason));
 						send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",	akill->desc, str_get_valid_display_value(akill->desc));
 						send_notice_to_user(sourceNick, callerUser, "Type: %#lx \2[\2%s\2]\2",		akill->type, get_akill_type_long(akill->type));
 						send_notice_to_user(sourceNick, callerUser, "ID: %lu-%s",					akill->id, get_akill_type_short(akill->type));
-						send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	akill->next, akill->prev);
+						send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	(void *)akill->next, (void *)akill->prev);
 					}
 
 					akill = akill->next;
@@ -1358,19 +1358,19 @@ void akill_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 								++akillIdx;
 
-								send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	akillIdx, akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason) + 4);
-								send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		akill->username, str_get_valid_display_value(akill->username));
-								send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		akill->host, str_get_valid_display_value(akill->host));
+								send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	akillIdx, (void *)akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason) + 4);
+								send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		(void *)akill->username, str_get_valid_display_value(akill->username));
+								send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		(void *)akill->host, str_get_valid_display_value(akill->host));
 								send_notice_to_user(sourceNick, callerUser, "CIDR: %u/%u",					akill->cidr.ip, akill->cidr.mask);
-								send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		akill->creator.name, str_get_valid_display_value(akill->creator.name));
+								send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		(void *)akill->creator.name, str_get_valid_display_value(akill->creator.name));
 								send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			akill->creator.time);
 								send_notice_to_user(sourceNick, callerUser, "Expiry C-time: %ld",			akill->expireTime);
 								send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		akill->lastUsed);
-								send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		akill->reason, str_get_valid_display_value(akill->reason));
-								send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",	akill->desc, str_get_valid_display_value(akill->desc));
+								send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)akill->reason, str_get_valid_display_value(akill->reason));
+								send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",	(void *)akill->desc, str_get_valid_display_value(akill->desc));
 								send_notice_to_user(sourceNick, callerUser, "Type: %#lx \2[\2%s\2]\2",		akill->type, get_akill_type_long(akill->type));
 								send_notice_to_user(sourceNick, callerUser, "ID: %lu-%s",					akill->id, get_akill_type_short(akill->type));
-								send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	akill->next, akill->prev);
+								send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	(void *)akill->next, (void *)akill->prev);
 							}
 
 							akill = akill->next;

--- a/src/akill.c
+++ b/src/akill.c
@@ -791,7 +791,7 @@ void handle_akill(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(reason)) > 220) {
 
-			send_notice_to_user(data->agent->nick, callerUser, "Reason cannot be longer than 220 characters (yours has: %d).", len);
+			send_notice_to_user(data->agent->nick, callerUser, "Reason cannot be longer than 220 characters (yours has: %lu).", len);
 			return;
 		}
 
@@ -1313,19 +1313,19 @@ void akill_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					if (str_match_wild_nocase(user, akill->username) &&
 						str_match_wild_nocase(host, akill->host)) {
 
-						send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",		akillIdx, (unsigned long)akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason));
-						send_notice_to_user(sourceNick, callerUser, "User: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->username, str_get_valid_display_value(akill->username));
-						send_notice_to_user(sourceNick, callerUser, "Host: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->host, str_get_valid_display_value(akill->host));
-						send_notice_to_user(sourceNick, callerUser, "CIDR: %u/%u",							akill->cidr.ip, akill->cidr.mask);
-						send_notice_to_user(sourceNick, callerUser, "Set by: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->creator.name, str_get_valid_display_value(akill->creator.name));
-						send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %lu",					akill->creator.time);
-						send_notice_to_user(sourceNick, callerUser, "Expiry C-time: %lu",					akill->expireTime);
-						send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %lu",				akill->lastUsed);
-						send_notice_to_user(sourceNick, callerUser, "Reason: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->reason, str_get_valid_display_value(akill->reason));
-						send_notice_to_user(sourceNick, callerUser, "Description: 0x%08X \2[\2%s\2]\2",		(unsigned long)akill->desc, str_get_valid_display_value(akill->desc));
-						send_notice_to_user(sourceNick, callerUser, "Type: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->type, get_akill_type_long(akill->type));
-						send_notice_to_user(sourceNick, callerUser, "ID: %lu-%s",							akill->id, get_akill_type_short(akill->type));
-						send_notice_to_user(sourceNick, callerUser, "Next/Prev records: 0x%08X / 0x%08X",	(unsigned long)akill->next, (unsigned long)akill->prev);
+						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	akillIdx, akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason));
+						send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		akill->username, str_get_valid_display_value(akill->username));
+						send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		akill->host, str_get_valid_display_value(akill->host));
+						send_notice_to_user(sourceNick, callerUser, "CIDR: %u/%u",					akill->cidr.ip, akill->cidr.mask);
+						send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		akill->creator.name, str_get_valid_display_value(akill->creator.name));
+						send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			akill->creator.time);
+						send_notice_to_user(sourceNick, callerUser, "Expiry C-time: %ld",			akill->expireTime);
+						send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		akill->lastUsed);
+						send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		akill->reason, str_get_valid_display_value(akill->reason));
+						send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",	akill->desc, str_get_valid_display_value(akill->desc));
+						send_notice_to_user(sourceNick, callerUser, "Type: %#lx \2[\2%s\2]\2",		akill->type, get_akill_type_long(akill->type));
+						send_notice_to_user(sourceNick, callerUser, "ID: %lu-%s",					akill->id, get_akill_type_short(akill->type));
+						send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	akill->next, akill->prev);
 					}
 
 					akill = akill->next;
@@ -1358,19 +1358,19 @@ void akill_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 								++akillIdx;
 
-								send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",		akillIdx, (unsigned long)akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason) + 4);
-								send_notice_to_user(sourceNick, callerUser, "User: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->username, str_get_valid_display_value(akill->username));
-								send_notice_to_user(sourceNick, callerUser, "Host: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->host, str_get_valid_display_value(akill->host));
-								send_notice_to_user(sourceNick, callerUser, "CIDR: %u/%u",							akill->cidr.ip, akill->cidr.mask);
-								send_notice_to_user(sourceNick, callerUser, "Set by: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->creator.name, str_get_valid_display_value(akill->creator.name));
-								send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %lu",					akill->creator.time);
-								send_notice_to_user(sourceNick, callerUser, "Expiry C-time: %lu",					akill->expireTime);
-								send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %lu",				akill->lastUsed);
-								send_notice_to_user(sourceNick, callerUser, "Reason: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->reason, str_get_valid_display_value(akill->reason));
-								send_notice_to_user(sourceNick, callerUser, "Description: 0x%08X \2[\2%s\2]\2",		(unsigned long)akill->desc, str_get_valid_display_value(akill->desc));
-								send_notice_to_user(sourceNick, callerUser, "Type: 0x%08X \2[\2%s\2]\2",			(unsigned long)akill->type, get_akill_type_long(akill->type));
-								send_notice_to_user(sourceNick, callerUser, "ID: %lu-%s",							akill->id, get_akill_type_short(akill->type));
-								send_notice_to_user(sourceNick, callerUser, "Next/Prev records: 0x%08X / 0x%08X",	(unsigned long)akill->next, (unsigned long)akill->prev);
+								send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	akillIdx, akill, sizeof(AutoKill) + str_len(akill->username) + str_len(akill->host) + str_len(akill->creator.name) + str_len(akill->reason) + 4);
+								send_notice_to_user(sourceNick, callerUser, "User: %p \2[\2%s\2]\2",		akill->username, str_get_valid_display_value(akill->username));
+								send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		akill->host, str_get_valid_display_value(akill->host));
+								send_notice_to_user(sourceNick, callerUser, "CIDR: %u/%u",					akill->cidr.ip, akill->cidr.mask);
+								send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		akill->creator.name, str_get_valid_display_value(akill->creator.name));
+								send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			akill->creator.time);
+								send_notice_to_user(sourceNick, callerUser, "Expiry C-time: %ld",			akill->expireTime);
+								send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		akill->lastUsed);
+								send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		akill->reason, str_get_valid_display_value(akill->reason));
+								send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",	akill->desc, str_get_valid_display_value(akill->desc));
+								send_notice_to_user(sourceNick, callerUser, "Type: %#lx \2[\2%s\2]\2",		akill->type, get_akill_type_long(akill->type));
+								send_notice_to_user(sourceNick, callerUser, "ID: %lu-%s",					akill->id, get_akill_type_short(akill->type));
+								send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	akill->next, akill->prev);
 							}
 
 							akill = akill->next;

--- a/src/akill.c
+++ b/src/akill.c
@@ -1376,7 +1376,7 @@ void akill_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 							akill = akill->next;
 						}
 
-						LOG_DEBUG_SNOOP("Command: DUMP AKILL ID %lu-%s -- by %s", id, type, callerUser->nick);
+						LOG_DEBUG_SNOOP("Command: DUMP AKILL ID %lu-%s -- by %s", t, type, callerUser->nick);
 					}
 					else
 						needSyntax = TRUE;

--- a/src/blacklist.c
+++ b/src/blacklist.c
@@ -364,7 +364,7 @@ void handle_blacklist(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(reason)) > 220) {
 
-			send_notice_to_user(s_OperServ, callerUser, "Reason cannot be longer than 220 characters (yours has: %lu).", len);
+			send_notice_to_user(s_OperServ, callerUser, "Reason cannot be longer than 220 characters (yours has: %zu).", len);
 			return;
 		}
 
@@ -687,7 +687,7 @@ void blacklist_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	addressIdx, (void *)anAddress, sizeof(BlackList));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",	addressIdx, (void *)anAddress, sizeof(BlackList));
 		send_notice_to_user(sourceNick, callerUser, "Value: %p \2[\2%s\2]\2",		(void *)anAddress->address, str_get_valid_display_value(anAddress->address));
 		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)anAddress->info.reason, str_get_valid_display_value(anAddress->info.reason));
 		send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		(void *)anAddress->info.creator.name, str_get_valid_display_value(anAddress->info.creator.name));

--- a/src/blacklist.c
+++ b/src/blacklist.c
@@ -687,14 +687,14 @@ void blacklist_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	addressIdx, anAddress, sizeof(BlackList));
-		send_notice_to_user(sourceNick, callerUser, "Value: %p \2[\2%s\2]\2",		anAddress->address, str_get_valid_display_value(anAddress->address));
-		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		anAddress->info.reason, str_get_valid_display_value(anAddress->info.reason));
-		send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		anAddress->info.creator.name, str_get_valid_display_value(anAddress->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	addressIdx, (void *)anAddress, sizeof(BlackList));
+		send_notice_to_user(sourceNick, callerUser, "Value: %p \2[\2%s\2]\2",		(void *)anAddress->address, str_get_valid_display_value(anAddress->address));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)anAddress->info.reason, str_get_valid_display_value(anAddress->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		(void *)anAddress->info.creator.name, str_get_valid_display_value(anAddress->info.creator.name));
 		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			anAddress->info.creator.time);
 		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		anAddress->lastUsed);
 		send_notice_to_user(sourceNick, callerUser, "Flags: %#x",					anAddress->flags);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	anAddress->next, anAddress->prev);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	(void *)anAddress->next, (void *)anAddress->prev);
 
 		if (sentIdx >= endIdx)
 			break;

--- a/src/blacklist.c
+++ b/src/blacklist.c
@@ -364,7 +364,7 @@ void handle_blacklist(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(reason)) > 220) {
 
-			send_notice_to_user(s_OperServ, callerUser, "Reason cannot be longer than 220 characters (yours has: %d).", len);
+			send_notice_to_user(s_OperServ, callerUser, "Reason cannot be longer than 220 characters (yours has: %lu).", len);
 			return;
 		}
 
@@ -687,14 +687,14 @@ void blacklist_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",		addressIdx, (unsigned long)anAddress, sizeof(BlackList));
-		send_notice_to_user(sourceNick, callerUser, "Value: 0x%08X \2[\2%s\2]\2",			(unsigned long)anAddress->address, str_get_valid_display_value(anAddress->address));
-		send_notice_to_user(sourceNick, callerUser, "Reason: 0x%08X \2[\2%s\2]\2",			(unsigned long)anAddress->info.reason, str_get_valid_display_value(anAddress->info.reason));
-		send_notice_to_user(sourceNick, callerUser, "Set by: 0x%08X \2[\2%s\2]\2",			(unsigned long)anAddress->info.creator.name, str_get_valid_display_value(anAddress->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",					anAddress->info.creator.time);
-		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",				anAddress->lastUsed);
-		send_notice_to_user(sourceNick, callerUser, "Flags: %d",							anAddress->flags);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: 0x%08X / 0x%08X",	(unsigned long)anAddress->next, (unsigned long)anAddress->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	addressIdx, anAddress, sizeof(BlackList));
+		send_notice_to_user(sourceNick, callerUser, "Value: %p \2[\2%s\2]\2",		anAddress->address, str_get_valid_display_value(anAddress->address));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		anAddress->info.reason, str_get_valid_display_value(anAddress->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		anAddress->info.creator.name, str_get_valid_display_value(anAddress->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			anAddress->info.creator.time);
+		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		anAddress->lastUsed);
+		send_notice_to_user(sourceNick, callerUser, "Flags: %#x",					anAddress->flags);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	anAddress->next, anAddress->prev);
 
 		if (sentIdx >= endIdx)
 			break;
@@ -729,6 +729,6 @@ unsigned long int blacklist_mem_report(CSTR sourceNick, const User *callerUser) 
 		anAddress = anAddress->next;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "BlackListed addresses: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "BlackListed addresses: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	return mem;
 }

--- a/src/channels.c
+++ b/src/channels.c
@@ -373,7 +373,7 @@ void chan_handle_SJOIN(CSTR source, const int ac, char **av) {
 			UserListItem *item, *next;
 
 
-			LOG_DEBUG("Received SJOIN for %s at %ld (-%ds) by %s, resetting channel.", chan_name, timestamp, (chan->creation_time - timestamp), nick_token_ptr);
+			LOG_DEBUG("Received SJOIN for %s at %ld (-%lds) by %s, resetting channel.", chan_name, timestamp, (chan->creation_time - timestamp), nick_token_ptr);
 
 			/* Reset channel modes. */
 			chan->mode = 0;
@@ -4851,7 +4851,7 @@ void handle_mode(CSTR source, User *callerUser, ServiceCommandData *data) {
 					send_globops(data->agent->nick, "\2%s\2 changed mode for user \2%s\2 to: \2%s\2", source, user->nick, modebuf);
 
 					LOG_SNOOP(s_OperServ, "%s M %s -- by %s (%s@%s) [%s]", data->agent->shortNick, user->nick, callerUser->nick, callerUser->username, callerUser->host, modebuf);
-					log_services(data->agent->logID, "M %s -- by %s (%s@%s) [%s]", data->agent->shortNick, user->nick, callerUser->nick, callerUser->username, callerUser->host, modebuf);
+					log_services(data->agent->logID, "M %s -- by %s (%s@%s) [%s]", user->nick, callerUser->nick, callerUser->username, callerUser->host, modebuf);
 				}
 				else {
 

--- a/src/channels.c
+++ b/src/channels.c
@@ -4911,7 +4911,7 @@ static void chan_ds_dump_display(CSTR sourceNick, const User *callerUser, const 
 			++ops;
 
 		send_notice_to_user(sourceNick, callerUser, "DUMP: channel \2%s\2", chan->name);
-		send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",		(void *)chan, sizeof(chan));
+		send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",		(void *)chan, sizeof(chan));
 		send_notice_to_user(sourceNick, callerUser, "Name: %s",						chan->name);
 		send_notice_to_user(sourceNick, callerUser, "Creation C-time: %ld",			chan->creation_time);
 		send_notice_to_user(sourceNick, callerUser, "Last topic: %p \2[\2%s\2]\2",	(void *)chan->topic, str_get_valid_display_value(chan->topic));

--- a/src/channels.c
+++ b/src/channels.c
@@ -4911,23 +4911,23 @@ static void chan_ds_dump_display(CSTR sourceNick, const User *callerUser, const 
 			++ops;
 
 		send_notice_to_user(sourceNick, callerUser, "DUMP: channel \2%s\2", chan->name);
-		send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",		chan, sizeof(chan));
+		send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",		(void *)chan, sizeof(chan));
 		send_notice_to_user(sourceNick, callerUser, "Name: %s",						chan->name);
 		send_notice_to_user(sourceNick, callerUser, "Creation C-time: %ld",			chan->creation_time);
-		send_notice_to_user(sourceNick, callerUser, "Last topic: %p \2[\2%s\2]\2",	chan->topic, str_get_valid_display_value(chan->topic));
+		send_notice_to_user(sourceNick, callerUser, "Last topic: %p \2[\2%s\2]\2",	(void *)chan->topic, str_get_valid_display_value(chan->topic));
 		send_notice_to_user(sourceNick, callerUser, "Last topic setter: %s",		chan->topic_setter);
 		send_notice_to_user(sourceNick, callerUser, "Last topic C-time: %ld",		chan->topic_time);
 
 		send_notice_to_user(sourceNick, callerUser, "Mode: %#lx (%s)",							(long unsigned int)chan->mode, get_channel_mode(chan->mode, 0));
-		send_notice_to_user(sourceNick, callerUser, "Mode +l/+k values: %ld / %p \2[\2%s\2]\2",	chan->limit, chan->key, str_get_valid_display_value(chan->key));
+		send_notice_to_user(sourceNick, callerUser, "Mode +l/+k values: %ld / %p \2[\2%s\2]\2",	chan->limit, (void *)chan->key, str_get_valid_display_value(chan->key));
 
-		send_notice_to_user(sourceNick, callerUser, "Bans count / list size / list head: %d / %d / %p",			chan->bancount, chan->bansize, chan->bans);
+		send_notice_to_user(sourceNick, callerUser, "Bans count / list size / list head: %d / %d / %p",			chan->bancount, chan->bansize, (void *)chan->bans);
 		send_notice_to_user(sourceNick, callerUser, "Users [%d/%d] / ops [%d] / halfops [%d] / voices [%d]",	chan->userCount, users, ops, halfops, voices);
-		send_notice_to_user(sourceNick, callerUser, "List heads: %p / %p / %p / %p",							chan->users, chan->chanops, chan->halfops, chan->voices);
+		send_notice_to_user(sourceNick, callerUser, "List heads: %p / %p / %p / %p",							(void *)chan->users, (void *)chan->chanops, (void *)chan->halfops, (void *)chan->voices);
 
-		send_notice_to_user(sourceNick, callerUser, "ChanInfo record: %p \2[\2%s\2]\2", chan->ci, chan->ci ? str_get_valid_display_value(chan->ci->name) : "NULL");
+		send_notice_to_user(sourceNick, callerUser, "ChanInfo record: %p \2[\2%s\2]\2", (void *)chan->ci, chan->ci ? str_get_valid_display_value(chan->ci->name) : "NULL");
 
-		send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p", chan->next, chan->prev);
+		send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p", (void *)chan->next, (void *)chan->prev);
 	}
 	else if (str_equals_nocase(what, "USER") || str_equals_nocase(what, "OP") || str_equals_nocase(what, "HALFOP")|| str_equals_nocase(what, "VOICE")) {
 
@@ -5054,7 +5054,7 @@ void chan_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			MemoryPoolStats pstats;
 
 			mempool_stats(channels_mempool, &pstats);
-			send_notice_to_user(sourceNick, callerUser, "DUMP: Channels memory pool - Address %p, ID: %u",	channels_mempool, pstats.id);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: Channels memory pool - Address %p, ID: %u",	(void *)channels_mempool, pstats.id);
 			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",			pstats.memory_allocated, pstats.memory_free);
 			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",				pstats.items_allocated, pstats.items_free);
 			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",			pstats.items_per_block, pstats.block_count);

--- a/src/channels.c
+++ b/src/channels.c
@@ -2543,7 +2543,7 @@ void chan_handle_TOPIC(const char *source, const int ac, char **av) {
 				str_copy_checked(ci->last_topic_setter, chan->topic_setter, NICKMAX);
 				chan->topic_time = ci->last_topic_time;
 
-				send_cmd(":%s TOPIC %s %s %lu :%s", s_ChanServ, chan->name, chan->topic_setter, chan->topic_time, chan->topic ? chan->topic : "");
+				send_cmd(":%s TOPIC %s %s %ld :%s", s_ChanServ, chan->name, chan->topic_setter, chan->topic_time, chan->topic ? chan->topic : "");
 				return;
 			}
 		}
@@ -2635,7 +2635,7 @@ void synch_topics() {
 
 				TRACE();
 				if (IS_NOT_NULL(chan->topic))
-					send_cmd(":%s TOPIC %s %s %lu :%s", s_ChanServ, chan->name, chan->topic_setter, chan->topic_time, chan->topic ? chan->topic : "");
+					send_cmd(":%s TOPIC %s %s %ld :%s", s_ChanServ, chan->name, chan->topic_setter, chan->topic_time, chan->topic ? chan->topic : "");
 			}
 		}
 	}
@@ -3638,7 +3638,7 @@ void handle_masscmds(CSTR source, User *callerUser, ServiceCommandData *data) {
 				AddFlag(chan->mode, CMODE_CS);
 			}
 
-			send_cmd(":%s MODE %s +b *!*@* %lu", s_ChanServ, chan_name, NOW);
+			send_cmd(":%s MODE %s +b *!*@* %ld", s_ChanServ, chan_name, NOW);
 
 			for (item = chan->users; item; item = next_item) {
 
@@ -3995,7 +3995,7 @@ void handle_mode(CSTR source, User *callerUser, ServiceCommandData *data) {
 							}
 
 							chan_add_ban(chan, token);
-							send_cmd(":%s MODE %s +b %s %lu", s_OperServ, chan->name, token, NOW);
+							send_cmd(":%s MODE %s +b %s %ld", s_OperServ, chan->name, token, NOW);
 
 							send_notice_to_user(s_OperServ, callerUser, "Channel ban on \2%s\2 added on \2%s\2.", token, chan->name);
 						}

--- a/src/channels.c
+++ b/src/channels.c
@@ -4911,23 +4911,23 @@ static void chan_ds_dump_display(CSTR sourceNick, const User *callerUser, const 
 			++ops;
 
 		send_notice_to_user(sourceNick, callerUser, "DUMP: channel \2%s\2", chan->name);
-		send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",				(unsigned long)chan, sizeof(chan));
-		send_notice_to_user(sourceNick, callerUser, "Name: %s",									chan->name);
-		send_notice_to_user(sourceNick, callerUser, "Creation C-time: %d",						chan->creation_time);
-		send_notice_to_user(sourceNick, callerUser, "Last topic: 0x%08X \2[\2%s\2]\2",			(unsigned long)chan->topic, str_get_valid_display_value(chan->topic));
-		send_notice_to_user(sourceNick, callerUser, "Last topic setter: %s",					chan->topic_setter);
-		send_notice_to_user(sourceNick, callerUser, "Last topic C-time: %d",					chan->topic_time);
+		send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",		chan, sizeof(chan));
+		send_notice_to_user(sourceNick, callerUser, "Name: %s",						chan->name);
+		send_notice_to_user(sourceNick, callerUser, "Creation C-time: %ld",			chan->creation_time);
+		send_notice_to_user(sourceNick, callerUser, "Last topic: %p \2[\2%s\2]\2",	chan->topic, str_get_valid_display_value(chan->topic));
+		send_notice_to_user(sourceNick, callerUser, "Last topic setter: %s",		chan->topic_setter);
+		send_notice_to_user(sourceNick, callerUser, "Last topic C-time: %ld",		chan->topic_time);
 
-		send_notice_to_user(sourceNick, callerUser, "Mode: %d (%s)",							chan->mode, get_channel_mode(chan->mode, 0));
-		send_notice_to_user(sourceNick, callerUser, "Mode +l/+k values: %d / 0x%08X \2[\2%s\2]\2",	chan->limit, (unsigned long)chan->key, str_get_valid_display_value(chan->key));
+		send_notice_to_user(sourceNick, callerUser, "Mode: %#lx (%s)",							(long unsigned int)chan->mode, get_channel_mode(chan->mode, 0));
+		send_notice_to_user(sourceNick, callerUser, "Mode +l/+k values: %ld / %p \2[\2%s\2]\2",	chan->limit, chan->key, str_get_valid_display_value(chan->key));
 
-		send_notice_to_user(sourceNick, callerUser, "Bans count / list size / list head: %d / %d / 0x%08X",			chan->bancount, chan->bansize, (unsigned long)chan->bans);
+		send_notice_to_user(sourceNick, callerUser, "Bans count / list size / list head: %d / %d / %p",			chan->bancount, chan->bansize, chan->bans);
 		send_notice_to_user(sourceNick, callerUser, "Users [%d/%d] / ops [%d] / halfops [%d] / voices [%d]",	chan->userCount, users, ops, halfops, voices);
-		send_notice_to_user(sourceNick, callerUser, "List heads: 0x%08X / 0x%08X / 0x%08X / 0x%08X",		(unsigned long)chan->users, (unsigned long)chan->chanops, (unsigned long)chan->halfops, (unsigned long)chan->voices);
+		send_notice_to_user(sourceNick, callerUser, "List heads: %p / %p / %p / %p",							chan->users, chan->chanops, chan->halfops, chan->voices);
 
-		send_notice_to_user(sourceNick, callerUser, "ChanInfo record: 0x%08X \2[\2%s\2]\2",		(unsigned long)chan->ci, chan->ci ? str_get_valid_display_value(chan->ci->name) : "NULL");
+		send_notice_to_user(sourceNick, callerUser, "ChanInfo record: %p \2[\2%s\2]\2", chan->ci, chan->ci ? str_get_valid_display_value(chan->ci->name) : "NULL");
 
-		send_notice_to_user(sourceNick, callerUser, "Next / previous record: 0x%08X / 0x%08X",	(unsigned long)chan->next, (unsigned long)chan->prev);
+		send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p", chan->next, chan->prev);
 	}
 	else if (str_equals_nocase(what, "USER") || str_equals_nocase(what, "OP") || str_equals_nocase(what, "HALFOP")|| str_equals_nocase(what, "VOICE")) {
 
@@ -5054,10 +5054,10 @@ void chan_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			MemoryPoolStats pstats;
 
 			mempool_stats(channels_mempool, &pstats);
-			send_notice_to_user(sourceNick, callerUser, "DUMP: Channels memory pool - Address 0x%08X, ID: %d",	(unsigned long)channels_mempool, pstats.id);
-			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %d B / %d B",				pstats.memory_allocated, pstats.memory_free);
-			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %d / %d",					pstats.items_allocated, pstats.items_free);
-			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %d / %d",			pstats.items_per_block, pstats.block_count);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: Channels memory pool - Address %p, ID: %u",	channels_mempool, pstats.id);
+			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",			pstats.memory_allocated, pstats.memory_free);
+			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",				pstats.items_allocated, pstats.items_free);
+			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",			pstats.items_per_block, pstats.block_count);
 			//send_notice_to_user(sourceNick, callerUser, "Avarage use: %.2f%%",								pstats.block_avg_usage);
 
 		#endif
@@ -5137,7 +5137,7 @@ unsigned long chan_mem_report(CSTR sourceNick, const User *callerUser) {
 	}
 
 	TRACE();
-	send_notice_to_user(sourceNick, callerUser, "Open channels: \2%d\2 [%d] -> \2%d\2 KB (\2%d\2 B)", count, stats_open_channels_count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Open channels: \2%lu\2 [%u] -> \2%lu\2 KB (\2%lu\2 B)", count, stats_open_channels_count, mem / 1024, mem);
 
 	return mem;
 }

--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -1288,7 +1288,7 @@ void expire_chans() {
 
 	TRACE();
 	if (CONF_DISPLAY_UPDATES)
-		send_globops(NULL, "Completed Channel Expire (\2%d\2/\2%d\2/\2%d\2)", xcount, rcount, count);
+		send_globops(NULL, "Completed Channel Expire (\2%ld\2/\2%ld\2/\2%ld\2)", xcount, rcount, count);
 	else
 		LOG_SNOOP(s_OperServ, "Completed Channel Expire (\2%ld\2/\2%ld\2/\2%ld\2)", xcount, rcount, count);
 }
@@ -1705,7 +1705,7 @@ static int masskick_channel(CSTR chan_name, LANG_MSG_ID reason) {
 			AddFlag(chan->mode, CMODE_CS);
 		}
 
-		send_cmd(":%s MODE %s +b *!*@* %lu", s_ChanServ, chan_name, NOW);
+		send_cmd(":%s MODE %s +b *!*@* %ld", s_ChanServ, chan_name, NOW);
 
 		for (item = chan->users; item; item = next_item) {
 
@@ -2423,7 +2423,7 @@ kick:
 
 	/* If this ban is not already present and can be added (i.e. banlist is not full) send it. */
 	if (!chan_has_ban(chan, mask, NULL) && chan_add_ban(chan, mask))
-		send_cmd(":%s MODE %s +b %s %lu", s_ChanServ, chan->name, mask, NOW);
+		send_cmd(":%s MODE %s +b %s %ld", s_ChanServ, chan->name, mask, NOW);
 
 	TRACE();
 	send_cmd(":%s KICK %s %s :%s", s_ChanServ, chan->name, user->nick, reason);
@@ -2494,7 +2494,7 @@ void restore_topic(Channel *chan) {
 
 	TRACE();
 	if (IS_NOT_NULL(chan->topic))
-		send_cmd(":%s TOPIC %s %s %lu :%s", s_ChanServ, chan->name, chan->topic_setter, chan->topic_time, chan->topic ? chan->topic : "");
+		send_cmd(":%s TOPIC %s %s %ld :%s", s_ChanServ, chan->name, chan->topic_setter, chan->topic_time, chan->topic ? chan->topic : "");
 }
 
 /*********************************************************/
@@ -2529,7 +2529,7 @@ BOOL check_topiclock(const User *user, Channel *chan) {
 	str_copy_checked(ci->last_topic_setter, chan->topic_setter, NICKMAX);
 	chan->topic_time = ci->last_topic_time;
 
-	send_cmd(":%s TOPIC %s %s %lu :%s", s_ChanServ, chan->name, chan->topic_setter, chan->topic_time, chan->topic ? chan->topic : "");
+	send_cmd(":%s TOPIC %s %s %ld :%s", s_ChanServ, chan->name, chan->topic_setter, chan->topic_time, chan->topic ? chan->topic : "");
 	return TRUE;
 }
 
@@ -2901,14 +2901,14 @@ static void do_register(CSTR source, User *callerUser, ServiceCommandData *data)
 
 		if (dynConf.cs_regLimit <= cs_regCount) {
 
-			send_globops(NULL, "\2%s\2 hit the maximum number of registrations allowed (\2%d\2/\2%d\2)",
+			send_globops(NULL, "\2%s\2 hit the maximum number of registrations allowed (\2%lu\2/\2%lu\2)",
 				s_ChanServ, cs_regCount, dynConf.cs_regLimit);
 			send_notice_lang_to_user(s_ChanServ, callerUser, GetCallerLang(), CSNS_ERROR_MAX_REG_REACHED);
 			return;
 		}
 		else if (dynConf.cs_regLimit <= (cs_regCount + 10)) {
 
-			send_globops(NULL, "\2%s\2 is about to hit the maximum number of registrations allowed (\2%d\2/\2%d\2)",
+			send_globops(NULL, "\2%s\2 is about to hit the maximum number of registrations allowed (\2%lu\2/\2%lu\2)",
 				s_ChanServ, cs_regCount, dynConf.cs_regLimit);
 		}
 	}
@@ -4373,7 +4373,7 @@ static void do_set_topic(User *callerUser, ChannelInfo *ci, CSTR param, const in
 		str_copy_checked(accessName, chan->topic_setter, NICKMAX);
 		chan->topic_time = NOW;
 
-		send_cmd(":%s TOPIC %s %s %lu :%s", s_ChanServ, ci->name, accessName, NOW, param);
+		send_cmd(":%s TOPIC %s %s %ld :%s", s_ChanServ, ci->name, accessName, NOW, param);
 		send_notice_lang_to_user(s_ChanServ, callerUser, GetCallerLang(), CS_SET_TOPIC_CHANGED, ci->name);
 
 		if (CSMatchVerbose(ci->settings, CI_NOTICE_VERBOSE_SET)) {
@@ -10835,7 +10835,7 @@ static void do_chanset(CSTR source, User *callerUser, ServiceCommandData *data) 
 				str_copy_checked(s_ChanServ, channel->topic_setter, NICKMAX);
 				channel->topic_time = NOW;
 
-				send_cmd(":%s TOPIC %s %s %lu :%s", s_ChanServ, chan, s_ChanServ, channel->topic_time, new_topic);
+				send_cmd(":%s TOPIC %s %s %ld :%s", s_ChanServ, chan, s_ChanServ, channel->topic_time, new_topic);
 			}
 
 			if (data->operMatch) {

--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -1290,7 +1290,7 @@ void expire_chans() {
 	if (CONF_DISPLAY_UPDATES)
 		send_globops(NULL, "Completed Channel Expire (\2%d\2/\2%d\2/\2%d\2)", xcount, rcount, count);
 	else
-		LOG_SNOOP(s_OperServ, "Completed Channel Expire (\2%d\2/\2%d\2/\2%d\2)", xcount, rcount, count);
+		LOG_SNOOP(s_OperServ, "Completed Channel Expire (\2%ld\2/\2%ld\2/\2%ld\2)", xcount, rcount, count);
 }
 
 /*********************************************************/
@@ -1350,9 +1350,9 @@ void chanserv_daily_expire() {
 
 	TRACE();
 	if (CONF_DISPLAY_UPDATES)
-		send_globops(NULL, "Completed Daily Channel Expire (Channels in database: \2%d\2)", count);
+		send_globops(NULL, "Completed Daily Channel Expire (Channels in database: \2%ld\2)", count);
 	else
-		LOG_SNOOP(s_OperServ, "Completed Daily Channel Expire (Channels in database: \2%d\2)", count);
+		LOG_SNOOP(s_OperServ, "Completed Daily Channel Expire (Channels in database: \2%ld\2)", count);
 }
 
 
@@ -1854,7 +1854,7 @@ void check_modelock(Channel *chan, User *changedBy) {
 
 	/* Some sanity checks (to be removed?). */
 	if (addKey && removeKey)
-		LOG_DEBUG_SNOOP("check_modelock() for channel %s has both addKey and removeKey!");
+		LOG_DEBUG_SNOOP("check_modelock() for channel %s has both addKey and removeKey!", chan->name);
 
 	/* No changes? Don't do anything. */
 	if (modeIdx == 0)
@@ -2619,7 +2619,7 @@ void cs_remove_nick(CSTR nick) {
 
 					/* Log this action. */
 					LOG_SNOOP(s_OperServ, "CS XF! %s [%s -> %s] [P: %s -> %s-%lu]", ci->name, ci->founder, ci->successor, ci->founderpass, CRYPT_NETNAME, randID);
-					log_services(LOG_SERVICES_CHANSERV_GENERAL, "XF! %s [%s -> %s] [P: %s -> %lu]", ci->name, ci->founder, ci->successor, ci->founderpass, CRYPT_NETNAME, randID);
+					log_services(LOG_SERVICES_CHANSERV_GENERAL, "XF! %s [%s -> %s] [P: %s -> %s-%lu]", ci->name, ci->founder, ci->successor, ci->founderpass, CRYPT_NETNAME, randID);
 
 					/* Change the channel password to the new (random) one. */
 					snprintf(ci->founderpass, sizeof(ci->founderpass), "%s-%lu", CRYPT_NETNAME, randID);
@@ -3160,23 +3160,32 @@ static void do_sendcode(CSTR source, User *callerUser, ServiceCommandData *data)
 	}	
 	if (IS_NULL(ci = cs_findchan(chan))) {
 
-		LOG_SNOOP(s_OperServ, "CS *SC %s -- by %s (%s@%s) [Not Registered]", chan, callerUser->nick, callerUser->username, callerUser->host);
+		if (data->operMatch)
+			LOG_SNOOP(s_OperServ, "CS *SC %s -- by %s (%s@%s) [Not Registered]", chan, callerUser->nick, callerUser->username, callerUser->host);
+		else
+			LOG_SNOOP(s_OperServ, "CS *SC %s -- by %s (%s@%s) through %s [Not Registered]", chan, callerUser->nick, callerUser->username, callerUser->host, data->operName);
 
 		send_notice_lang_to_user(s_ChanServ, callerUser, GetCallerLang(), ERROR_CHAN_NOT_REG, chan);
 		return;
 	}
 	
 	if(!ci->auth) {
-		
-		LOG_SNOOP(s_OperServ, "CS *SC -- by %s (%s@%s) [NO Dropping requests]", callerUser->nick, callerUser->username, callerUser->host, data->operName, NICKMAX);
+
+		if (data->operMatch)
+			LOG_SNOOP(s_OperServ, "CS *SC -- by %s (%s@%s) [NO Dropping requests]", callerUser->nick, callerUser->username, callerUser->host);
+		else
+			LOG_SNOOP(s_OperServ, "CS *SC -- by %s (%s@%s) through %s [NO Dropping requests]", callerUser->nick, callerUser->username, callerUser->host, data->operName);
 
 		send_notice_lang_to_user(s_ChanServ, callerUser, GetCallerLang(), CS_DROP_ERROR_NOT_DROPPING, ci->name);
 		return;
 	}	
 	
 	if(FlagSet(ci->flags,  CI_MARKCHAN)) {
-		
-		LOG_SNOOP(s_OperServ, "CS *SC -- by %s (%s@%s) [Marked]", callerUser->nick, callerUser->username, callerUser->host, data->operName, NICKMAX);
+
+		if (data->operMatch)
+			LOG_SNOOP(s_OperServ, "CS *SC -- by %s (%s@%s) [Marked]", callerUser->nick, callerUser->username, callerUser->host);
+		else
+			LOG_SNOOP(s_OperServ, "CS *SC -- by %s (%s@%s) through %s [Marked]", callerUser->nick, callerUser->username, callerUser->host, data->operName);
 
 		send_notice_lang_to_user(s_ChanServ, callerUser, GetCallerLang(), OPER_CS_ERROR_CHAN_MARKED, ci->name);
 		return;
@@ -3212,8 +3221,13 @@ static void do_sendcode(CSTR source, User *callerUser, ServiceCommandData *data)
 			
 		send_notice_lang_to_user(s_ChanServ, callerUser, GetCallerLang(), CSNS_SENDCODE_CODE_SENT, ni->nick, ni->email);
 		send_globops(s_ChanServ, "\2%s\2 used SENDCODE on channel \2%s\2 [DROP]", callerUser->nick, ci->name);
-		LOG_SNOOP(s_OperServ, "CS SC %s -- by %s (%s@%s)", ci->name, callerUser->nick, callerUser->username, callerUser->host);
-		log_services(LOG_SERVICES_CHANSERV_GENERAL, "SC %s -- by %s (%s@%s)", ci->name, callerUser->nick, callerUser->username, callerUser->host);
+		if (data->operMatch) {
+			LOG_SNOOP(s_OperServ, "CS SC %s -- by %s (%s@%s)", ci->name, callerUser->nick, callerUser->username, callerUser->host);
+			log_services(LOG_SERVICES_CHANSERV_GENERAL, "SC %s -- by %s (%s@%s)", ci->name, callerUser->nick, callerUser->username, callerUser->host);
+		} else {
+			LOG_SNOOP(s_OperServ, "CS SC %s -- by %s (%s@%s) through %s", ci->name, callerUser->nick, callerUser->username, callerUser->host, data->operName);
+			log_services(LOG_SERVICES_CHANSERV_GENERAL, "SC %s -- by %s (%s@%s) through %s", ci->name, callerUser->nick, callerUser->username, callerUser->host, data->operName);
+		}
 	
 	}	
 	else
@@ -10618,7 +10632,7 @@ static void do_chanset(CSTR source, User *callerUser, ServiceCommandData *data) 
 			BOOL was_on_list = FALSE;
 			int idx;
 			User *newUser;
-			long int randID;
+			long unsigned int randID;
 			char memoText[512];
 
 
@@ -10653,7 +10667,7 @@ static void do_chanset(CSTR source, User *callerUser, ServiceCommandData *data) 
 			else {
 
 				LOG_SNOOP(s_OperServ, "CS T %s -- by %s (%s@%s) through %s [F: %s -> %s]", ci->name, callerUser->nick, callerUser->username, callerUser->host, data->operName, ci->founder, ni->nick);
-				log_services(LOG_SERVICES_CHANSERV_GENERAL, "T %s -- by %s (%s@%s) through %s [F: %s -> %s] [P: %s -> %lu]", ci->name, callerUser->nick, callerUser->username, callerUser->host, data->operName, ci->founder, ni->nick, ci->founderpass, CRYPT_NETNAME, randID);
+				log_services(LOG_SERVICES_CHANSERV_GENERAL, "T %s -- by %s (%s@%s) through %s [F: %s -> %s] [P: %s -> %s-%lu]", ci->name, callerUser->nick, callerUser->username, callerUser->host, data->operName, ci->founder, ni->nick, ci->founderpass, CRYPT_NETNAME, randID);
 
 				send_globops(s_ChanServ, "\2%s\2 (through \2%s\2) changed the founder of \2%s\2 to \2%s\2", callerUser->nick, data->operName, ci->name, ni->nick);
 			}
@@ -10879,15 +10893,15 @@ static void do_chanset(CSTR source, User *callerUser, ServiceCommandData *data) 
 
 		if (data->operMatch) {
 
-			LOG_SNOOP(s_OperServ, "CS T %s -- by %s (%s@%s) [R: %lu -> %lu]", ci->name, callerUser->nick, callerUser->username, callerUser->host, ci->time_registered, newTime);
-			log_services(LOG_SERVICES_CHANSERV_GENERAL, "T %s -- by %s (%s@%s) [R: %lu -> %lu]", ci->name, callerUser->nick, callerUser->username, callerUser->host, ci->time_registered, newTime);
+			LOG_SNOOP(s_OperServ, "CS T %s -- by %s (%s@%s) [R: %ld -> %ld]", ci->name, callerUser->nick, callerUser->username, callerUser->host, ci->time_registered, newTime);
+			log_services(LOG_SERVICES_CHANSERV_GENERAL, "T %s -- by %s (%s@%s) [R: %ld -> %ld]", ci->name, callerUser->nick, callerUser->username, callerUser->host, ci->time_registered, newTime);
 
 			send_globops(s_ChanServ, "\2%s\2 changed registration date for \2%s\2 to: %s (was: %s)", callerUser->nick, ci->name, newtimebuf, timebuf);
 		}
 		else {
 
-			LOG_SNOOP(s_OperServ, "CS T %s -- by %s (%s@%s) through %s [D: %lu -> %lu]", ci->name, callerUser->nick, callerUser->username, callerUser->host, data->operName, ci->time_registered, newTime);
-			log_services(LOG_SERVICES_CHANSERV_GENERAL, "T %s -- by %s (%s@%s) through %s [D: %lu -> %lu]", ci->name, callerUser->nick, callerUser->username, callerUser->host, data->operName, ci->time_registered, newTime);
+			LOG_SNOOP(s_OperServ, "CS T %s -- by %s (%s@%s) through %s [D: %ld -> %ld]", ci->name, callerUser->nick, callerUser->username, callerUser->host, data->operName, ci->time_registered, newTime);
+			log_services(LOG_SERVICES_CHANSERV_GENERAL, "T %s -- by %s (%s@%s) through %s [D: %ld -> %ld]", ci->name, callerUser->nick, callerUser->username, callerUser->host, data->operName, ci->time_registered, newTime);
 
 			send_globops(s_ChanServ, "\2%s\2 (through \2%s\2) changed registration date for \2%s\2 to: %s (was: %s)", callerUser->nick, data->operName, ci->name, newtimebuf, timebuf);
 		}

--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -11749,7 +11749,7 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: channel \2%s\2", value);
 
-					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",						(void *)ci, sizeof(ChannelInfo));
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",						(void *)ci, sizeof(ChannelInfo));
 					send_notice_to_user(sourceNick, callerUser, "Name: %s",										ci->name);
 					send_notice_to_user(sourceNick, callerUser, "Founder: %s",									ci->founder);
 					send_notice_to_user(sourceNick, callerUser, "Password: [REDACTED]");
@@ -11825,7 +11825,7 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 							break;
 					}
 
-					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B", i+1,	(void *)anAccess, sizeof(ChanAccess));
+					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B", i+1,	(void *)anAccess, sizeof(ChanAccess));
 					send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			(void *)anAccess->name, str_get_valid_display_value(anAccess->name));
 					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			(void *)anAccess->creator, str_get_valid_display_value(anAccess->creator));
 					send_notice_to_user(sourceNick, callerUser, "Time Created C-time: %ld",			anAccess->creationTime);
@@ -11853,7 +11853,7 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				for (anAkick = ci->akick, i = 0; i < ci->akickcount; ++anAkick, ++i) {
 
-					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B", i+1,	(void *)anAkick, sizeof(AutoKick));
+					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B", i+1,	(void *)anAkick, sizeof(AutoKick));
 					send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			(void *)anAkick->name, str_get_valid_display_value(anAkick->name));
 					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			(void *)anAkick->creator, str_get_valid_display_value(anAkick->creator));
 					send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",			(void *)anAkick->reason, str_get_valid_display_value(anAkick->reason));

--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -11749,35 +11749,35 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: channel \2%s\2", value);
 
-					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",						ci, sizeof(ChannelInfo));
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",						(void *)ci, sizeof(ChannelInfo));
 					send_notice_to_user(sourceNick, callerUser, "Name: %s",										ci->name);
 					send_notice_to_user(sourceNick, callerUser, "Founder: %s",									ci->founder);
 					send_notice_to_user(sourceNick, callerUser, "Password: [REDACTED]");
-					send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",					ci->desc, str_get_valid_display_value(ci->desc));
+					send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",					(void *)ci->desc, str_get_valid_display_value(ci->desc));
 					send_notice_to_user(sourceNick, callerUser, "Registration C-time: %ld",						ci->time_registered);
 					send_notice_to_user(sourceNick, callerUser, "Last used C-time: %ld",						ci->last_used);
-					send_notice_to_user(sourceNick, callerUser, "Access count / list: %ld / %p",				ci->accesscount, ci->access);
-					send_notice_to_user(sourceNick, callerUser, "AKICK count / list: %ld / %p",					ci->akickcount, ci->akick);
+					send_notice_to_user(sourceNick, callerUser, "Access count / list: %ld / %p",				ci->accesscount, (void *)ci->access);
+					send_notice_to_user(sourceNick, callerUser, "AKICK count / list: %ld / %p",					ci->akickcount, (void *)ci->akick);
 					send_notice_to_user(sourceNick, callerUser, "ModeLock ON/OFF: %#lx/%#lx (%s)",				ci->mlock_on, ci->mlock_off, get_channel_mode(ci->mlock_on, ci->mlock_off));
-					send_notice_to_user(sourceNick, callerUser, "MLOCK +l/+k values: %ld / %p \2[\2%s\2]\2",	ci->mlock_limit, ci->mlock_key, str_get_valid_display_value(ci->mlock_key));
-					send_notice_to_user(sourceNick, callerUser, "Last topic: %p \2[\2%s\2]\2",					ci->last_topic, str_get_valid_display_value(ci->last_topic));
+					send_notice_to_user(sourceNick, callerUser, "MLOCK +l/+k values: %ld / %p \2[\2%s\2]\2",	ci->mlock_limit, (void *)ci->mlock_key, str_get_valid_display_value(ci->mlock_key));
+					send_notice_to_user(sourceNick, callerUser, "Last topic: %p \2[\2%s\2]\2",					(void *)ci->last_topic, str_get_valid_display_value(ci->last_topic));
 					send_notice_to_user(sourceNick, callerUser, "Last topic setter: %s",						ci->last_topic_setter);
 					send_notice_to_user(sourceNick, callerUser, "Last topic C-time: %ld",						ci->last_topic_time);
 					send_notice_to_user(sourceNick, callerUser, "Flags: %#lx",									ci->flags);
-					send_notice_to_user(sourceNick, callerUser, "Successor: %p \2[\2%s\2]\2",					ci->successor, str_get_valid_display_value(ci->successor));
-					send_notice_to_user(sourceNick, callerUser, "URL: %p \2[\2%s\2]\2",							ci->url, str_get_valid_display_value(ci->url));
-					send_notice_to_user(sourceNick, callerUser, "e-mail: %p \2[\2%s\2]\2",						ci->email, str_get_valid_display_value(ci->email));
-					send_notice_to_user(sourceNick, callerUser, "Welcome notice: %p \2[\2%s\2]\2",				ci->welcome, str_get_valid_display_value(ci->welcome));
-					send_notice_to_user(sourceNick, callerUser, "Hold by: %p \2[\2%s\2]\2",						ci->hold, str_get_valid_display_value(ci->hold));
-					send_notice_to_user(sourceNick, callerUser, "Marked by: %p \2[\2%s\2]\2",					ci->mark, str_get_valid_display_value(ci->mark));
-					send_notice_to_user(sourceNick, callerUser, "Frozen by: %p \2[\2%s\2]\2",					ci->freeze, str_get_valid_display_value(ci->freeze));
-					send_notice_to_user(sourceNick, callerUser, "Forbidden by: %p \2[\2%s\2]\2",				ci->forbid, str_get_valid_display_value(ci->forbid));
+					send_notice_to_user(sourceNick, callerUser, "Successor: %p \2[\2%s\2]\2",					(void *)ci->successor, str_get_valid_display_value(ci->successor));
+					send_notice_to_user(sourceNick, callerUser, "URL: %p \2[\2%s\2]\2",							(void *)ci->url, str_get_valid_display_value(ci->url));
+					send_notice_to_user(sourceNick, callerUser, "e-mail: %p \2[\2%s\2]\2",						(void *)ci->email, str_get_valid_display_value(ci->email));
+					send_notice_to_user(sourceNick, callerUser, "Welcome notice: %p \2[\2%s\2]\2",				(void *)ci->welcome, str_get_valid_display_value(ci->welcome));
+					send_notice_to_user(sourceNick, callerUser, "Hold by: %p \2[\2%s\2]\2",						(void *)ci->hold, str_get_valid_display_value(ci->hold));
+					send_notice_to_user(sourceNick, callerUser, "Marked by: %p \2[\2%s\2]\2",					(void *)ci->mark, str_get_valid_display_value(ci->mark));
+					send_notice_to_user(sourceNick, callerUser, "Frozen by: %p \2[\2%s\2]\2",					(void *)ci->freeze, str_get_valid_display_value(ci->freeze));
+					send_notice_to_user(sourceNick, callerUser, "Forbidden by: %p \2[\2%s\2]\2",				(void *)ci->forbid, str_get_valid_display_value(ci->forbid));
 					send_notice_to_user(sourceNick, callerUser, "Auth code: %lu",								ci->auth);
 					send_notice_to_user(sourceNick, callerUser, "Settings: %#lx",								(long unsigned int)ci->settings);
-					send_notice_to_user(sourceNick, callerUser, "Real founder: %p \2[\2%s\2]\2",				ci->real_founder, str_get_valid_display_value(ci->real_founder));
+					send_notice_to_user(sourceNick, callerUser, "Real founder: %p \2[\2%s\2]\2",				(void *)ci->real_founder, str_get_valid_display_value(ci->real_founder));
 					send_notice_to_user(sourceNick, callerUser, "Ban Type: %d",									(int)ci->banType);
 					send_notice_to_user(sourceNick, callerUser, "reserved[2]: %d %d",							ci->reserved[0], ci->reserved[1]);
-					send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",				ci->next, ci->prev);
+					send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",				(void *)ci->next, (void *)ci->prev);
 
 					LOG_DEBUG_SNOOP("Command: DUMP CHANSERV CHAN %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -11825,9 +11825,9 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 							break;
 					}
 
-					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B", i+1,	anAccess, sizeof(ChanAccess));
-					send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			anAccess->name, str_get_valid_display_value(anAccess->name));
-					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			anAccess->creator, str_get_valid_display_value(anAccess->creator));
+					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B", i+1,	(void *)anAccess, sizeof(ChanAccess));
+					send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			(void *)anAccess->name, str_get_valid_display_value(anAccess->name));
+					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			(void *)anAccess->creator, str_get_valid_display_value(anAccess->creator));
 					send_notice_to_user(sourceNick, callerUser, "Time Created C-time: %ld",			anAccess->creationTime);
 					send_notice_to_user(sourceNick, callerUser, "Level: %d \2[\2%s\2]\2",			anAccess->level, level_name);
 					send_notice_to_user(sourceNick, callerUser, "Status: %d \2[\2%s\2]\2",			anAccess->status, access_type);
@@ -11853,10 +11853,10 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				for (anAkick = ci->akick, i = 0; i < ci->akickcount; ++anAkick, ++i) {
 
-					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B", i+1,	anAkick, sizeof(AutoKick));
-					send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			anAkick->name, str_get_valid_display_value(anAkick->name));
-					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			anAkick->creator, str_get_valid_display_value(anAkick->creator));
-					send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",			anAkick->reason, str_get_valid_display_value(anAkick->reason));
+					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B", i+1,	(void *)anAkick, sizeof(AutoKick));
+					send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			(void *)anAkick->name, str_get_valid_display_value(anAkick->name));
+					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			(void *)anAkick->creator, str_get_valid_display_value(anAkick->creator));
+					send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",			(void *)anAkick->reason, str_get_valid_display_value(anAkick->reason));
 					send_notice_to_user(sourceNick, callerUser, "Time Created C-time: %ld",			anAkick->creationTime);
 					send_notice_to_user(sourceNick, callerUser, "banType / isNick: %d/%d",			anAkick->banType, anAkick->isNick);
 					send_notice_to_user(sourceNick, callerUser, "Flags: %d",						anAkick->flags);
@@ -11873,7 +11873,7 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			MemoryPoolStats pstats;
 
 			mempool_stats(chandb_mempool, &pstats);
-			send_notice_to_user(sourceNick, callerUser, "DUMP: ChanServ memory pool - Address %p, ID: %u",	chandb_mempool, pstats.id);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: ChanServ memory pool - Address %p, ID: %u",	(void *)chandb_mempool, pstats.id);
 			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",			pstats.memory_allocated, pstats.memory_free);
 			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",				pstats.items_allocated, pstats.items_free);
 			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",			pstats.items_per_block, pstats.block_count);

--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -6102,14 +6102,14 @@ static void do_info(CSTR source, User *callerUser, ServiceCommandData *data) {
 				if (ci->mlock_key) {
 
 					if (ci->mlock_limit)
-						send_notice_to_user(s_ChanServ, callerUser, "Modelock: %s %s %d", get_channel_mode(ci->mlock_on, ci->mlock_off), ci->mlock_key, ci->mlock_limit);
+						send_notice_to_user(s_ChanServ, callerUser, "Modelock: %s %s %ld", get_channel_mode(ci->mlock_on, ci->mlock_off), ci->mlock_key, ci->mlock_limit);
 					else
 						send_notice_to_user(s_ChanServ, callerUser, "Modelock: %s %s", get_channel_mode(ci->mlock_on, ci->mlock_off), ci->mlock_key);
 				}
 				else {
 
 					if (ci->mlock_limit)
-						send_notice_to_user(s_ChanServ, callerUser, "Modelock: %s %d", get_channel_mode(ci->mlock_on, ci->mlock_off), ci->mlock_limit);
+						send_notice_to_user(s_ChanServ, callerUser, "Modelock: %s %ld", get_channel_mode(ci->mlock_on, ci->mlock_off), ci->mlock_limit);
 					else
 						send_notice_lang_to_user(s_ChanServ, callerUser, GetCallerLang(), CS_INFO_MODELOCK, get_channel_mode(ci->mlock_on, ci->mlock_off));
 				}
@@ -11354,9 +11354,9 @@ static void do_listreg(CSTR source, User *callerUser, ServiceCommandData *data) 
 					continue;
 
 				if (FlagSet(ci->flags, CI_FORBIDDEN))
-					send_notice_to_user(s_ChanServ, callerUser, "%d) \2%s\2 [Forbidden by: %s]", line, ci->name, ci->forbid);
+					send_notice_to_user(s_ChanServ, callerUser, "%lu) \2%s\2 [Forbidden by: %s]", line, ci->name, ci->forbid);
 				else
-					send_notice_to_user(s_ChanServ, callerUser, "%d) \2%s\2 [Founder: %s]", line, ci->name, ci->founder);
+					send_notice_to_user(s_ChanServ, callerUser, "%lu) \2%s\2 [Founder: %s]", line, ci->name, ci->founder);
 
 				if (line >= end_line) {
 
@@ -11749,35 +11749,35 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: channel \2%s\2", value);
 
-					send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",						(unsigned long)ci, sizeof(ChannelInfo));
-					send_notice_to_user(sourceNick, callerUser, "Name: %s",											ci->name);
-					send_notice_to_user(sourceNick, callerUser, "Founder: %s",										ci->founder);
-					send_notice_to_user(sourceNick, callerUser, "Password: %s",										ci->founderpass);
-					send_notice_to_user(sourceNick, callerUser, "Description: 0x%08X \2[\2%s\2]\2",					(unsigned long)ci->desc, str_get_valid_display_value(ci->desc));
-					send_notice_to_user(sourceNick, callerUser, "Registration C-time: %d",							ci->time_registered);
-					send_notice_to_user(sourceNick, callerUser, "Last used C-time: %d",								ci->last_used);
-					send_notice_to_user(sourceNick, callerUser, "Access count / list: %d / 0x%08X",					ci->accesscount, (unsigned long)ci->access);
-					send_notice_to_user(sourceNick, callerUser, "AKICK count / list: %d / 0x%08X",					ci->akickcount, (unsigned long)ci->akick);
-					send_notice_to_user(sourceNick, callerUser, "ModeLock ON/OFF: %d/%d (%s)",						ci->mlock_on, ci->mlock_off, get_channel_mode(ci->mlock_on, ci->mlock_off));
-					send_notice_to_user(sourceNick, callerUser, "MLOCK +l/+k values: %d / 0x%08X \2[\2%s\2]\2",		ci->mlock_limit, (unsigned long)ci->mlock_key, str_get_valid_display_value(ci->mlock_key));
-					send_notice_to_user(sourceNick, callerUser, "Last topic: 0x%08X \2[\2%s\2]\2",					(unsigned long)ci->last_topic, str_get_valid_display_value(ci->last_topic));
-					send_notice_to_user(sourceNick, callerUser, "Last topic setter: %s",							ci->last_topic_setter);
-					send_notice_to_user(sourceNick, callerUser, "Last topic C-time: %d",							ci->last_topic_time);
-					send_notice_to_user(sourceNick, callerUser, "Flags: %d",										ci->flags);
-					send_notice_to_user(sourceNick, callerUser, "Successor: 0x%08X \2[\2%s\2]\2",					(unsigned long)ci->successor, str_get_valid_display_value(ci->successor));
-					send_notice_to_user(sourceNick, callerUser, "URL: 0x%08X \2[\2%s\2]\2",							(unsigned long)ci->url, str_get_valid_display_value(ci->url));
-					send_notice_to_user(sourceNick, callerUser, "e-mail: 0x%08X \2[\2%s\2]\2",						(unsigned long)ci->email, str_get_valid_display_value(ci->email));
-					send_notice_to_user(sourceNick, callerUser, "Welcome notice: 0x%08X \2[\2%s\2]\2",				(unsigned long)ci->welcome, str_get_valid_display_value(ci->welcome));
-					send_notice_to_user(sourceNick, callerUser, "Hold by: 0x%08X \2[\2%s\2]\2",						(unsigned long)ci->hold, str_get_valid_display_value(ci->hold));
-					send_notice_to_user(sourceNick, callerUser, "Marked by: 0x%08X \2[\2%s\2]\2",					(unsigned long)ci->mark, str_get_valid_display_value(ci->mark));
-					send_notice_to_user(sourceNick, callerUser, "Frozen by: 0x%08X \2[\2%s\2]\2",					(unsigned long)ci->freeze, str_get_valid_display_value(ci->freeze));
-					send_notice_to_user(sourceNick, callerUser, "Forbidden by: 0x%08X \2[\2%s\2]\2",				(unsigned long)ci->forbid, str_get_valid_display_value(ci->forbid));
-					send_notice_to_user(sourceNick, callerUser, "Auth code: %d",									ci->auth);
-					send_notice_to_user(sourceNick, callerUser, "Settings: %d",										ci->settings);
-					send_notice_to_user(sourceNick, callerUser, "Real founder: 0x%08X \2[\2%s\2]\2",				(unsigned long)ci->real_founder, str_get_valid_display_value(ci->real_founder));
-					send_notice_to_user(sourceNick, callerUser, "Ban Type: %d",										(int)ci->banType);
-					send_notice_to_user(sourceNick, callerUser, "reserved[2]: %d %d",								ci->reserved[0], ci->reserved[1]);
-					send_notice_to_user(sourceNick, callerUser, "Next / previous record: 0x%08X / 0x%08X",			(unsigned long)ci->next, (unsigned long)ci->prev);
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",						ci, sizeof(ChannelInfo));
+					send_notice_to_user(sourceNick, callerUser, "Name: %s",										ci->name);
+					send_notice_to_user(sourceNick, callerUser, "Founder: %s",									ci->founder);
+					send_notice_to_user(sourceNick, callerUser, "Password: [REDACTED]");
+					send_notice_to_user(sourceNick, callerUser, "Description: %p \2[\2%s\2]\2",					ci->desc, str_get_valid_display_value(ci->desc));
+					send_notice_to_user(sourceNick, callerUser, "Registration C-time: %ld",						ci->time_registered);
+					send_notice_to_user(sourceNick, callerUser, "Last used C-time: %ld",						ci->last_used);
+					send_notice_to_user(sourceNick, callerUser, "Access count / list: %ld / %p",				ci->accesscount, ci->access);
+					send_notice_to_user(sourceNick, callerUser, "AKICK count / list: %ld / %p",					ci->akickcount, ci->akick);
+					send_notice_to_user(sourceNick, callerUser, "ModeLock ON/OFF: %#lx/%#lx (%s)",				ci->mlock_on, ci->mlock_off, get_channel_mode(ci->mlock_on, ci->mlock_off));
+					send_notice_to_user(sourceNick, callerUser, "MLOCK +l/+k values: %ld / %p \2[\2%s\2]\2",	ci->mlock_limit, ci->mlock_key, str_get_valid_display_value(ci->mlock_key));
+					send_notice_to_user(sourceNick, callerUser, "Last topic: %p \2[\2%s\2]\2",					ci->last_topic, str_get_valid_display_value(ci->last_topic));
+					send_notice_to_user(sourceNick, callerUser, "Last topic setter: %s",						ci->last_topic_setter);
+					send_notice_to_user(sourceNick, callerUser, "Last topic C-time: %ld",						ci->last_topic_time);
+					send_notice_to_user(sourceNick, callerUser, "Flags: %#lx",									ci->flags);
+					send_notice_to_user(sourceNick, callerUser, "Successor: %p \2[\2%s\2]\2",					ci->successor, str_get_valid_display_value(ci->successor));
+					send_notice_to_user(sourceNick, callerUser, "URL: %p \2[\2%s\2]\2",							ci->url, str_get_valid_display_value(ci->url));
+					send_notice_to_user(sourceNick, callerUser, "e-mail: %p \2[\2%s\2]\2",						ci->email, str_get_valid_display_value(ci->email));
+					send_notice_to_user(sourceNick, callerUser, "Welcome notice: %p \2[\2%s\2]\2",				ci->welcome, str_get_valid_display_value(ci->welcome));
+					send_notice_to_user(sourceNick, callerUser, "Hold by: %p \2[\2%s\2]\2",						ci->hold, str_get_valid_display_value(ci->hold));
+					send_notice_to_user(sourceNick, callerUser, "Marked by: %p \2[\2%s\2]\2",					ci->mark, str_get_valid_display_value(ci->mark));
+					send_notice_to_user(sourceNick, callerUser, "Frozen by: %p \2[\2%s\2]\2",					ci->freeze, str_get_valid_display_value(ci->freeze));
+					send_notice_to_user(sourceNick, callerUser, "Forbidden by: %p \2[\2%s\2]\2",				ci->forbid, str_get_valid_display_value(ci->forbid));
+					send_notice_to_user(sourceNick, callerUser, "Auth code: %lu",								ci->auth);
+					send_notice_to_user(sourceNick, callerUser, "Settings: %#lx",								(long unsigned int)ci->settings);
+					send_notice_to_user(sourceNick, callerUser, "Real founder: %p \2[\2%s\2]\2",				ci->real_founder, str_get_valid_display_value(ci->real_founder));
+					send_notice_to_user(sourceNick, callerUser, "Ban Type: %d",									(int)ci->banType);
+					send_notice_to_user(sourceNick, callerUser, "reserved[2]: %d %d",							ci->reserved[0], ci->reserved[1]);
+					send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",				ci->next, ci->prev);
 
 					LOG_DEBUG_SNOOP("Command: DUMP CHANSERV CHAN %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -11825,13 +11825,13 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 							break;
 					}
 
-					send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B", i+1,	(unsigned long)anAccess, sizeof(ChanAccess));
-					send_notice_to_user(sourceNick, callerUser, "Name: 0x%08X \2[\2%s\2]\2",			(unsigned long)anAccess->name, str_get_valid_display_value(anAccess->name));
-					send_notice_to_user(sourceNick, callerUser, "Creator: 0x%08X \2[\2%s\2]\2",			(unsigned long)anAccess->creator, str_get_valid_display_value(anAccess->creator));
-					send_notice_to_user(sourceNick, callerUser, "Time Created C-time: %d",				anAccess->creationTime);
-					send_notice_to_user(sourceNick, callerUser, "Level: %d \2[\2%s\2]\2",				anAccess->level, level_name);
-					send_notice_to_user(sourceNick, callerUser, "Status: %d \2[\2%s\2]\2",				anAccess->status, access_type);
-					send_notice_to_user(sourceNick, callerUser, "Flags: %d",							anAccess->flags);
+					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B", i+1,	anAccess, sizeof(ChanAccess));
+					send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			anAccess->name, str_get_valid_display_value(anAccess->name));
+					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			anAccess->creator, str_get_valid_display_value(anAccess->creator));
+					send_notice_to_user(sourceNick, callerUser, "Time Created C-time: %ld",			anAccess->creationTime);
+					send_notice_to_user(sourceNick, callerUser, "Level: %d \2[\2%s\2]\2",			anAccess->level, level_name);
+					send_notice_to_user(sourceNick, callerUser, "Status: %d \2[\2%s\2]\2",			anAccess->status, access_type);
+					send_notice_to_user(sourceNick, callerUser, "Flags: %d",						anAccess->flags);
 				}
 
 				LOG_DEBUG_SNOOP("Command: DUMP CHANSERV CHAN %s -- by %s (%s@%s) [ACCESS]", value, callerUser->nick, callerUser->username, callerUser->host);
@@ -11853,13 +11853,13 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				for (anAkick = ci->akick, i = 0; i < ci->akickcount; ++anAkick, ++i) {
 
-					send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B", i+1,	(unsigned long)anAkick, sizeof(AutoKick));
-					send_notice_to_user(sourceNick, callerUser, "Name: 0x%08X \2[\2%s\2]\2",			(unsigned long)anAkick->name, str_get_valid_display_value(anAkick->name));
-					send_notice_to_user(sourceNick, callerUser, "Creator: 0x%08X \2[\2%s\2]\2",			(unsigned long)anAkick->creator, str_get_valid_display_value(anAkick->creator));
-					send_notice_to_user(sourceNick, callerUser, "Reason: 0x%08X \2[\2%s\2]\2",			(unsigned long)anAkick->reason, str_get_valid_display_value(anAkick->reason));
-					send_notice_to_user(sourceNick, callerUser, "Time Created C-time: %d",				anAkick->creationTime);
-					send_notice_to_user(sourceNick, callerUser, "banType / isNick: %d/%d",				anAkick->banType, anAkick->isNick);
-					send_notice_to_user(sourceNick, callerUser, "Flags: %d",							anAkick->flags);
+					send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B", i+1,	anAkick, sizeof(AutoKick));
+					send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			anAkick->name, str_get_valid_display_value(anAkick->name));
+					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			anAkick->creator, str_get_valid_display_value(anAkick->creator));
+					send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",			anAkick->reason, str_get_valid_display_value(anAkick->reason));
+					send_notice_to_user(sourceNick, callerUser, "Time Created C-time: %ld",			anAkick->creationTime);
+					send_notice_to_user(sourceNick, callerUser, "banType / isNick: %d/%d",			anAkick->banType, anAkick->isNick);
+					send_notice_to_user(sourceNick, callerUser, "Flags: %d",						anAkick->flags);
 				}
 
 				LOG_DEBUG_SNOOP("Command: DUMP CHANSERV CHAN %s -- by %s (%s@%s) [AKICK]", value, callerUser->nick, callerUser->username, callerUser->host);
@@ -11873,10 +11873,10 @@ void chanserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			MemoryPoolStats pstats;
 
 			mempool_stats(chandb_mempool, &pstats);
-			send_notice_to_user(sourceNick, callerUser, "DUMP: ChanServ memory pool - Address 0x%08X, ID: %d",	(unsigned long)chandb_mempool, pstats.id);
-			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %d B / %d B",				pstats.memory_allocated, pstats.memory_free);
-			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %d / %d",					pstats.items_allocated, pstats.items_free);
-			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %d / %d",			pstats.items_per_block, pstats.block_count);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: ChanServ memory pool - Address %p, ID: %u",	chandb_mempool, pstats.id);
+			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",			pstats.memory_allocated, pstats.memory_free);
+			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",				pstats.items_allocated, pstats.items_free);
+			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",			pstats.items_per_block, pstats.block_count);
 			//send_notice_to_user(sourceNick, callerUser, "Avarage use: %.2f%%",								pstats.block_avg_usage);
 
 		#endif
@@ -11962,7 +11962,7 @@ unsigned long chanserv_mem_report(CSTR sourceNick, const User *callerUser) {
 		}
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Record: \2%d\2 [%d] -> \2%d\2 KB (\2%d\2 B)", count, cs_regCount, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Record: \2%lu\2 [%lu] -> \2%lu\2 KB (\2%lu\2 B)", count, cs_regCount, mem / 1024, mem);
 
 	return mem;
 }

--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -1032,7 +1032,7 @@ void load_suspend_db(void) {
 		}
 #else
 		if (fread(name, sizeof(ChannelSuspendData), 1, f) != 1)
-			fatal_error(FACILITY_CHANSERV_LOAD_SUSPEND_DB, __LINE__, "Read error on %s at entry %d", SUSPEND_DB, i);ù
+			fatal_error(FACILITY_CHANSERV_LOAD_SUSPEND_DB, __LINE__, "Read error on %s at entry %d", SUSPEND_DB, i);
 
 #endif
 		TRACE();

--- a/src/conf.c
+++ b/src/conf.c
@@ -1546,30 +1546,30 @@ void handle_set(const char *source, User *callerUser, ServiceCommandData *data) 
 
 			TRACE_MAIN();
 			if (data->operMatch)
-				LOG_SNOOP(data->agent->nick, "%s +SET* SCANV6 -- by %s (%s@%s) [Already set to %d]", data->agent->shortNick, callerUser->nick, callerUser->username, callerUser->host, value);
+				LOG_SNOOP(data->agent->nick, "%s +SET* SCANV6 -- by %s (%s@%s) [Already set to %ld]", data->agent->shortNick, callerUser->nick, callerUser->username, callerUser->host, value);
 			else
-				LOG_SNOOP(data->agent->nick, "%s +SET* SCANV6 -- by %s (%s@%s) through %s [Already set to %d]", data->agent->shortNick, callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
+				LOG_SNOOP(data->agent->nick, "%s +SET* SCANV6 -- by %s (%s@%s) through %s [Already set to %ld]", data->agent->shortNick, callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
 
-			send_notice_to_user(data->agent->nick, callerUser, "SCANV6 is already set to \2%d\2.", value);
+			send_notice_to_user(data->agent->nick, callerUser, "SCANV6 is already set to \2%ld\2.", value);
 		}
 		else {
 
 			if (data->operMatch) {
 
-				LOG_SNOOP(data->agent->nick, "%s +SET SCANV6 -- by %s (%s@%s) [%d -> %d]", data->agent->shortNick, callerUser->nick, callerUser->username, callerUser->host, CONF_CLONE_SCAN_V6, value);
-				log_services(data->agent->logID, "+SET SCANV6 -- by %s (%s@%s) [%d -> %d]", callerUser->nick, callerUser->username, callerUser->host, CONF_CLONE_SCAN_V6, value);
+				LOG_SNOOP(data->agent->nick, "%s +SET SCANV6 -- by %s (%s@%s) [%d -> %ld]", data->agent->shortNick, callerUser->nick, callerUser->username, callerUser->host, CONF_CLONE_SCAN_V6, value);
+				log_services(data->agent->logID, "+SET SCANV6 -- by %s (%s@%s) [%d -> %ld]", callerUser->nick, callerUser->username, callerUser->host, CONF_CLONE_SCAN_V6, value);
 
-				send_globops(data->agent->nick, "\2%s\2 enabled V6 Clone Detection at field \2%d\2", source, value);
+				send_globops(data->agent->nick, "\2%s\2 enabled V6 Clone Detection at field \2%ld\2", source, value);
 			}
 			else {
 
-				LOG_SNOOP(data->agent->nick, "%s +SET SCANV6 -- by %s (%s@%s) through %s [%d -> %d]", data->agent->shortNick, callerUser->nick, callerUser->username, callerUser->host, data->operName, CONF_CLONE_SCAN_V6, value);
-				log_services(data->agent->logID, "+SET SCANV6 -- by %s (%s@%s) through %s [%d -> %d]", callerUser->nick, callerUser->username, callerUser->host, data->operName, CONF_CLONE_SCAN_V6, value);
+				LOG_SNOOP(data->agent->nick, "%s +SET SCANV6 -- by %s (%s@%s) through %s [%d -> %ld]", data->agent->shortNick, callerUser->nick, callerUser->username, callerUser->host, data->operName, CONF_CLONE_SCAN_V6, value);
+				log_services(data->agent->logID, "+SET SCANV6 -- by %s (%s@%s) through %s [%d -> %ld]", callerUser->nick, callerUser->username, callerUser->host, data->operName, CONF_CLONE_SCAN_V6, value);
 
-				send_globops(data->agent->nick, "\2%s\2 (through \2%s\2) enabled V6 Clone Detection at field \2%d\2", source, data->operName, value);
+				send_globops(data->agent->nick, "\2%s\2 (through \2%s\2) enabled V6 Clone Detection at field \2%ld\2", source, data->operName, value);
 			}
 
-			send_notice_to_user(data->agent->nick, callerUser, "Services is now V6 Clone Detecting at field \2%d\2.", value);
+			send_notice_to_user(data->agent->nick, callerUser, "Services is now V6 Clone Detecting at field \2%ld\2.", value);
 
 			CONF_CLONE_SCAN_V6 = value;
 		}

--- a/src/crypt_userhost.c
+++ b/src/crypt_userhost.c
@@ -270,7 +270,8 @@ STR crypt_userhost(CSTR real, HOST_TYPE htype, short int dotsCount) {
 
 	size_t			len, virlen;
 	int32_t			hash;
-	char			*ptr, *expanded_real = real;
+	char			*ptr;
+	CSTR expanded_real = real;
 	char expanded_real_buf[40];
 
 	#define MAX_DSN_HOST_LEN	64

--- a/src/crypt_userhost.c
+++ b/src/crypt_userhost.c
@@ -168,10 +168,10 @@ void handle_cryptkey(CSTR source, User *callerUser, ServiceCommandData *data) {
 		send_notice_to_user(data->agent->nick, callerUser, "Syntax: \2CRYPTKEY\2 newkey");
 
 	else if ((keyLen = str_len(newKey)) < HIDEHOST_MIN_KEY_LEN)
-		send_notice_to_user(data->agent->nick, callerUser, "The key is too short [%d < %d]", keyLen, HIDEHOST_MIN_KEY_LEN);
+		send_notice_to_user(data->agent->nick, callerUser, "The key is too short [%lu < %d]", keyLen, HIDEHOST_MIN_KEY_LEN);
 
 	else if (keyLen > HIDEHOST_MAX_KEY_LEN)
-		send_notice_to_user(data->agent->nick, callerUser, "The key is too long [%d > %d]", keyLen, HIDEHOST_MAX_KEY_LEN);
+		send_notice_to_user(data->agent->nick, callerUser, "The key is too long [%lu > %d]", keyLen, HIDEHOST_MAX_KEY_LEN);
 
 	else {
 
@@ -387,13 +387,13 @@ void crypt_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			// HELP !
 
 		} else if (str_equals_nocase(cmd, "HOSTBUFF")) {
-			send_notice_to_user(sourceNick, callerUser, "DUMP: [%d] %s", hidehost_buffer_size, str_get_valid_display_value(hidehost_buffer));
+			send_notice_to_user(sourceNick, callerUser, "DUMP: [%lu] %s", hidehost_buffer_size, str_get_valid_display_value(hidehost_buffer));
 
 		} else if (str_equals_nocase(cmd, "HOSTCRYPT")) {
-			send_notice_to_user(sourceNick, callerUser, "DUMP: [%d] %s", hidehost_crypt_buffer_size, str_get_valid_display_value(hidehost_crypt_buffer));
+			send_notice_to_user(sourceNick, callerUser, "DUMP: [%lu] %s", hidehost_crypt_buffer_size, str_get_valid_display_value(hidehost_crypt_buffer));
 
 		} else if (str_equals_nocase(cmd, "KEY")) {
-			send_notice_to_user(sourceNick, callerUser, "DUMP: [%d] %s", hidehost_key_size, str_get_valid_display_value(hidehost_key));
+			send_notice_to_user(sourceNick, callerUser, "DUMP: [%lu] %s", hidehost_key_size, str_get_valid_display_value(hidehost_key));
 
 		} else
 			needSyntax = TRUE;

--- a/src/crypt_userhost.c
+++ b/src/crypt_userhost.c
@@ -168,10 +168,10 @@ void handle_cryptkey(CSTR source, User *callerUser, ServiceCommandData *data) {
 		send_notice_to_user(data->agent->nick, callerUser, "Syntax: \2CRYPTKEY\2 newkey");
 
 	else if ((keyLen = str_len(newKey)) < HIDEHOST_MIN_KEY_LEN)
-		send_notice_to_user(data->agent->nick, callerUser, "The key is too short [%lu < %d]", keyLen, HIDEHOST_MIN_KEY_LEN);
+		send_notice_to_user(data->agent->nick, callerUser, "The key is too short [%zu < %d]", keyLen, HIDEHOST_MIN_KEY_LEN);
 
 	else if (keyLen > HIDEHOST_MAX_KEY_LEN)
-		send_notice_to_user(data->agent->nick, callerUser, "The key is too long [%lu > %d]", keyLen, HIDEHOST_MAX_KEY_LEN);
+		send_notice_to_user(data->agent->nick, callerUser, "The key is too long [%zu > %d]", keyLen, HIDEHOST_MAX_KEY_LEN);
 
 	else {
 
@@ -387,13 +387,13 @@ void crypt_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			// HELP !
 
 		} else if (str_equals_nocase(cmd, "HOSTBUFF")) {
-			send_notice_to_user(sourceNick, callerUser, "DUMP: [%lu] %s", hidehost_buffer_size, str_get_valid_display_value(hidehost_buffer));
+			send_notice_to_user(sourceNick, callerUser, "DUMP: [%zu] %s", hidehost_buffer_size, str_get_valid_display_value(hidehost_buffer));
 
 		} else if (str_equals_nocase(cmd, "HOSTCRYPT")) {
-			send_notice_to_user(sourceNick, callerUser, "DUMP: [%lu] %s", hidehost_crypt_buffer_size, str_get_valid_display_value(hidehost_crypt_buffer));
+			send_notice_to_user(sourceNick, callerUser, "DUMP: [%zu] %s", hidehost_crypt_buffer_size, str_get_valid_display_value(hidehost_crypt_buffer));
 
 		} else if (str_equals_nocase(cmd, "KEY")) {
-			send_notice_to_user(sourceNick, callerUser, "DUMP: [%lu] %s", hidehost_key_size, str_get_valid_display_value(hidehost_key));
+			send_notice_to_user(sourceNick, callerUser, "DUMP: [%zu] %s", hidehost_key_size, str_get_valid_display_value(hidehost_key));
 
 		} else
 			needSyntax = TRUE;

--- a/src/debugserv.c
+++ b/src/debugserv.c
@@ -501,7 +501,7 @@ static void do_set(const char *source, User *callerUser, ServiceCommandData *dat
 
 						snprintf(misc_buffer, sizeof(misc_buffer), s_DS_IBD_ACTIVATED, source);
 						send_notice_to_user(s_DebugServ, callerUser, misc_buffer);
-						LOG_DEBUG_SNOOP(misc_buffer);
+						LOG_DEBUG_SNOOP("%s", misc_buffer);
 						log_debug_direct(misc_buffer);
 
 						if (IS_NOT_NULL(debug_monitor_inputbuffer_filter))
@@ -522,7 +522,7 @@ static void do_set(const char *source, User *callerUser, ServiceCommandData *dat
 
 						snprintf(misc_buffer, sizeof(misc_buffer), s_DS_IBD_DEACTIVATED, source);
 						send_notice_to_user(s_DebugServ, callerUser, misc_buffer);
-						LOG_DEBUG_SNOOP(misc_buffer);
+						LOG_DEBUG_SNOOP("%s", misc_buffer);
 						log_debug_direct(misc_buffer);
 
 						if (IS_NOT_NULL(debug_monitor_inputbuffer_filter)) {
@@ -713,7 +713,7 @@ static void do_inject(const char *source, User *callerUser, ServiceCommandData *
 	else {
 
 		LOG_DEBUG_SNOOP("\2%s\2 had me INJECT the following command:", source);
-		LOG_DEBUG_SNOOP(command);
+		LOG_DEBUG_SNOOP("%s", command);
 		log_debug_direct(command);
 
 		if (store_flag == 'Y') {

--- a/src/debugserv.c
+++ b/src/debugserv.c
@@ -344,9 +344,9 @@ static void do_mem(const char *source, User *callerUser, ServiceCommandData *dat
 		return;
 	}
 
-	send_notice_to_user(s_DebugServ, callerUser, s_SPACE);
-	send_notice_to_user(s_DebugServ, callerUser, "Memory usage: \2%d\2 KB (\2%d\2 B)", total_memory / 1024, total_memory);
-	send_notice_to_user(s_DebugServ, callerUser, s_SPACE);
+	send_notice_to_user(s_DebugServ, callerUser, " ");
+	send_notice_to_user(s_DebugServ, callerUser, "Memory usage: \2%lu\2 KB (\2%lu\2 B)", total_memory / 1024, total_memory);
+	send_notice_to_user(s_DebugServ, callerUser, " ");
 	send_notice_to_user(s_DebugServ, callerUser, "*** \2End of MEM Stats\2 ***");
 
 	LOG_DEBUG_SNOOP("Command: MEM -- by %s", source);
@@ -405,7 +405,7 @@ static void do_show(const char *source, User *callerUser, ServiceCommandData *da
 		TRACE_MAIN();
 		send_notice_to_user(s_DebugServ, callerUser, "Last error input buffer:");
 		send_notice_to_user(s_DebugServ, callerUser, "%s %s %s", log_get_last_error_timestamp(), log_get_last_error_signature(), log_get_last_error_trace());
-		send_notice_to_user(s_DebugServ, callerUser, log_get_last_error_buffer());
+		send_notice_to_user(s_DebugServ, callerUser, "%s", log_get_last_error_buffer());
 		LOG_DEBUG_SNOOP("Command: SHOW LASTERRBUF -- by %s", source);
 	
 	} else if (str_equals_nocase(what, "TS")) {
@@ -500,7 +500,7 @@ static void do_set(const char *source, User *callerUser, ServiceCommandData *dat
 						conf_monitor_inputbuffer = TRUE;
 
 						snprintf(misc_buffer, sizeof(misc_buffer), s_DS_IBD_ACTIVATED, source);
-						send_notice_to_user(s_DebugServ, callerUser, misc_buffer);
+						send_notice_to_user(s_DebugServ, callerUser, "%s", misc_buffer);
 						LOG_DEBUG_SNOOP("%s", misc_buffer);
 						log_debug_direct(misc_buffer);
 
@@ -521,7 +521,7 @@ static void do_set(const char *source, User *callerUser, ServiceCommandData *dat
 						conf_monitor_inputbuffer = FALSE;
 
 						snprintf(misc_buffer, sizeof(misc_buffer), s_DS_IBD_DEACTIVATED, source);
-						send_notice_to_user(s_DebugServ, callerUser, misc_buffer);
+						send_notice_to_user(s_DebugServ, callerUser, "%s", misc_buffer);
 						LOG_DEBUG_SNOOP("%s", misc_buffer);
 						log_debug_direct(misc_buffer);
 
@@ -546,6 +546,10 @@ static void do_set(const char *source, User *callerUser, ServiceCommandData *dat
  * /msg DebugServ CRYPT                                  *
  *********************************************************/
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wformat"
+#endif /* __GNUC__ */
 static void do_crypt(const char *source, User *callerUser, ServiceCommandData *data) {
 	STR		type = strtok(NULL, s_SPACE);
 	STR		what = strtok(NULL, s_SPACE);
@@ -585,7 +589,9 @@ static void do_crypt(const char *source, User *callerUser, ServiceCommandData *d
 		LOG_DEBUG_SNOOP("Command: CRYPT FNV %s -- by %s", what, source);
 	}
 }
-
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif /* __GNUC__ */
 
 /*********************************************************
  * /msg DebugServ DUMP                                   *
@@ -1140,7 +1146,7 @@ static void do_sysinfo(const char *source, User *callerUser, ServiceCommandData 
 			);
 	
 	// Database options
-	send_notice_to_user(s_DebugServ, callerUser, "Database options: Read-only \2%s\2 - No-expire \2%s\2 - Backup \2%s\2 - Update frequency: \2%d\2 secs",
+	send_notice_to_user(s_DebugServ, callerUser, "Database options: Read-only \2%s\2 - No-expire \2%s\2 - Backup \2%s\2 - Update frequency: \2%ld\2 secs",
 		CONF_SET_READONLY ? s_ENABLED : s_DISABLED, CONF_SET_NOEXPIRE ? s_ENABLED : s_DISABLED, CONF_DATABASE_BACKUP_FREQUENCY ? s_ENABLED : s_DISABLED, CONF_DATABASE_UPDATE_FREQUENCY);
 
 	stg_report_sysinfo(s_DebugServ, callerUser->nick);
@@ -1157,7 +1163,7 @@ static void do_sysinfo(const char *source, User *callerUser, ServiceCommandData 
 		CONF_SET_DEBUG ? s_ENABLED : s_DISABLED, CONF_DEBUG_CHAN, conf_monitor_inputbuffer ? s_ENABLED : s_DISABLED, conf_monitor_inputbuffer ? debug_monitor_inputbuffer_filter : s_NULL, debug_inject ? s_ON : s_OFF);
 
 	// misc options
-	send_notice_to_user(s_DebugServ, callerUser, "Misc options: Timeout-check frequency \2%d\2 secs", CONF_TIMEOUT_CHECK);
+	send_notice_to_user(s_DebugServ, callerUser, "Misc options: Timeout-check frequency \2%ld\2 secs", CONF_TIMEOUT_CHECK);
 
 	#ifndef NEW_SOCK
 	send_notice_to_user(s_DebugServ, callerUser, "Timeout-check startup delta \2%d\2 secs", CONF_TIMEOUT_STARTUP_DELTA);

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -938,7 +938,7 @@ void ignore_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	ignoreIdx, (void *)anIgnore, sizeof(Ignore));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",	ignoreIdx, (void *)anIgnore, sizeof(Ignore));
 		send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",		(void *)anIgnore->nick, str_get_valid_display_value(anIgnore->nick));
 		send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",	(void *)anIgnore->username, str_get_valid_display_value(anIgnore->username));
 		send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		(void *)anIgnore->host, str_get_valid_display_value(anIgnore->host));

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -938,17 +938,17 @@ void ignore_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	ignoreIdx, anIgnore, sizeof(Ignore));
-		send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",		anIgnore->nick, str_get_valid_display_value(anIgnore->nick));
-		send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",	anIgnore->username, str_get_valid_display_value(anIgnore->username));
-		send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		anIgnore->host, str_get_valid_display_value(anIgnore->host));
-		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		anIgnore->info.creator.name, str_get_valid_display_value(anIgnore->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		anIgnore->info.reason, str_get_valid_display_value(anIgnore->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	ignoreIdx, (void *)anIgnore, sizeof(Ignore));
+		send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",		(void *)anIgnore->nick, str_get_valid_display_value(anIgnore->nick));
+		send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",	(void *)anIgnore->username, str_get_valid_display_value(anIgnore->username));
+		send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		(void *)anIgnore->host, str_get_valid_display_value(anIgnore->host));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		(void *)anIgnore->info.creator.name, str_get_valid_display_value(anIgnore->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)anIgnore->info.reason, str_get_valid_display_value(anIgnore->info.reason));
 		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			anIgnore->info.creator.time);
 		send_notice_to_user(sourceNick, callerUser, "Expire C-time: %ld",			anIgnore->expireTime);
 		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		anIgnore->lastUsed);
 		send_notice_to_user(sourceNick, callerUser, "Flags: %d",					anIgnore->flags);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	anIgnore->next, anIgnore->prev);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	(void *)anIgnore->next, (void *)anIgnore->prev);
 
 		if (ignoreIdx >= endIdx)
 			break;

--- a/src/ignore.c
+++ b/src/ignore.c
@@ -533,7 +533,7 @@ void handle_ignore(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((idx = str_len(reason)) > 220) {
 
-			send_notice_to_user(s_OperServ, callerUser, "Reason cannot be longer than 220 characters (yours has: %d).", idx);
+			send_notice_to_user(s_OperServ, callerUser, "Reason cannot be longer than 220 characters (yours has: %u).", idx);
 			return;
 		}
 
@@ -938,17 +938,17 @@ void ignore_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",		ignoreIdx, (unsigned long)anIgnore, sizeof(Ignore));
-		send_notice_to_user(sourceNick, callerUser, "Nick: 0x%08X \2[\2%s\2]\2",			(unsigned long)anIgnore->nick, str_get_valid_display_value(anIgnore->nick));
-		send_notice_to_user(sourceNick, callerUser, "Username: 0x%08X \2[\2%s\2]\2",		(unsigned long)anIgnore->username, str_get_valid_display_value(anIgnore->username));
-		send_notice_to_user(sourceNick, callerUser, "Host: 0x%08X \2[\2%s\2]\2",			(unsigned long)anIgnore->host, str_get_valid_display_value(anIgnore->host));
-		send_notice_to_user(sourceNick, callerUser, "Creator: 0x%08X \2[\2%s\2]\2",			(unsigned long)anIgnore->info.creator.name, str_get_valid_display_value(anIgnore->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Reason: 0x%08X \2[\2%s\2]\2",			(unsigned long)anIgnore->info.reason, str_get_valid_display_value(anIgnore->info.reason));
-		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %d",					anIgnore->info.creator.time);
-		send_notice_to_user(sourceNick, callerUser, "Expire C-time: %d",					anIgnore->expireTime);
-		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %d",					anIgnore->lastUsed);
-		send_notice_to_user(sourceNick, callerUser, "Flags: %d",							anIgnore->flags);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: 0x%08X / 0x%08X",	(unsigned long)anIgnore->next, (unsigned long)anIgnore->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	ignoreIdx, anIgnore, sizeof(Ignore));
+		send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",		anIgnore->nick, str_get_valid_display_value(anIgnore->nick));
+		send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",	anIgnore->username, str_get_valid_display_value(anIgnore->username));
+		send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		anIgnore->host, str_get_valid_display_value(anIgnore->host));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		anIgnore->info.creator.name, str_get_valid_display_value(anIgnore->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		anIgnore->info.reason, str_get_valid_display_value(anIgnore->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			anIgnore->info.creator.time);
+		send_notice_to_user(sourceNick, callerUser, "Expire C-time: %ld",			anIgnore->expireTime);
+		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		anIgnore->lastUsed);
+		send_notice_to_user(sourceNick, callerUser, "Flags: %d",					anIgnore->flags);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	anIgnore->next, anIgnore->prev);
 
 		if (ignoreIdx >= endIdx)
 			break;
@@ -991,6 +991,6 @@ unsigned long int ignore_mem_report(CSTR sourceNick, const User *callerUser) {
 		anIgnore = anIgnore->next;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Ignore List: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Ignore List: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	return mem;
 }

--- a/src/jupe.c
+++ b/src/jupe.c
@@ -154,7 +154,7 @@ void handle_jupe(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(reason)) > SERVER_DESC_MAX) {
 
-			send_notice_to_user(s_OperServ, callerUser, "Maximum length for a jupe reason is %d characters. Yours has: %u", SERVER_DESC_MAX, len);
+			send_notice_to_user(s_OperServ, callerUser, "Maximum length for a jupe reason is %d characters. Yours has: %lu", SERVER_DESC_MAX, len);
 			return;
 		}
 
@@ -383,7 +383,7 @@ void handle_jupe(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(reason)) > SERVER_DESC_MAX) {
 
-			send_notice_to_user(s_OperServ, callerUser, "Maximum length for a jupe reason is %d characters. Yours has: %u", SERVER_DESC_MAX, len);
+			send_notice_to_user(s_OperServ, callerUser, "Maximum length for a jupe reason is %d characters. Yours has: %lu", SERVER_DESC_MAX, len);
 			return;
 		}
 
@@ -573,12 +573,12 @@ void jupe_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",		jupeIdx, (unsigned long)aJupe, sizeof(Jupe));
-		send_notice_to_user(sourceNick, callerUser, "Server: 0x%08X \2[\2%s\2]\2",			(unsigned long)aJupe->name, str_get_valid_display_value(aJupe->name));
-		send_notice_to_user(sourceNick, callerUser, "Creator: 0x%08X \2[\2%s\2]\2",			(unsigned long)aJupe->info.creator.name, str_get_valid_display_value(aJupe->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Reason: 0x%08X \2[\2%s\2]\2",			(unsigned long)aJupe->info.reason, str_get_valid_display_value(aJupe->info.reason));
-		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %d",					aJupe->info.creator.time);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: 0x%08X / 0x%08X",	(unsigned long)aJupe->next, (unsigned long)aJupe->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	jupeIdx, aJupe, sizeof(Jupe));
+		send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",		aJupe->name, str_get_valid_display_value(aJupe->name));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		aJupe->info.creator.name, str_get_valid_display_value(aJupe->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		aJupe->info.reason, str_get_valid_display_value(aJupe->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			aJupe->info.creator.time);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	aJupe->next, aJupe->prev);
 
 		if (sentIdx >= endIdx)
 			break;
@@ -613,6 +613,6 @@ unsigned long int jupe_mem_report(CSTR sourceNick, const User *callerUser) {
 		aJupe = aJupe->next;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Jupe List: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Jupe List: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	return mem;
 }

--- a/src/jupe.c
+++ b/src/jupe.c
@@ -154,7 +154,7 @@ void handle_jupe(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(reason)) > SERVER_DESC_MAX) {
 
-			send_notice_to_user(s_OperServ, callerUser, "Maximum length for a jupe reason is %d characters. Yours has: %lu", SERVER_DESC_MAX, len);
+			send_notice_to_user(s_OperServ, callerUser, "Maximum length for a jupe reason is %d characters. Yours has: %zu", SERVER_DESC_MAX, len);
 			return;
 		}
 
@@ -383,7 +383,7 @@ void handle_jupe(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(reason)) > SERVER_DESC_MAX) {
 
-			send_notice_to_user(s_OperServ, callerUser, "Maximum length for a jupe reason is %d characters. Yours has: %lu", SERVER_DESC_MAX, len);
+			send_notice_to_user(s_OperServ, callerUser, "Maximum length for a jupe reason is %d characters. Yours has: %zu", SERVER_DESC_MAX, len);
 			return;
 		}
 
@@ -573,7 +573,7 @@ void jupe_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	jupeIdx, (void *)aJupe, sizeof(Jupe));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",	jupeIdx, (void *)aJupe, sizeof(Jupe));
 		send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",		(void *)aJupe->name, str_get_valid_display_value(aJupe->name));
 		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		(void *)aJupe->info.creator.name, str_get_valid_display_value(aJupe->info.creator.name));
 		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)aJupe->info.reason, str_get_valid_display_value(aJupe->info.reason));

--- a/src/jupe.c
+++ b/src/jupe.c
@@ -573,12 +573,12 @@ void jupe_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	jupeIdx, aJupe, sizeof(Jupe));
-		send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",		aJupe->name, str_get_valid_display_value(aJupe->name));
-		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		aJupe->info.creator.name, str_get_valid_display_value(aJupe->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		aJupe->info.reason, str_get_valid_display_value(aJupe->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	jupeIdx, (void *)aJupe, sizeof(Jupe));
+		send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",		(void *)aJupe->name, str_get_valid_display_value(aJupe->name));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		(void *)aJupe->info.creator.name, str_get_valid_display_value(aJupe->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)aJupe->info.reason, str_get_valid_display_value(aJupe->info.reason));
 		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			aJupe->info.creator.time);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	aJupe->next, aJupe->prev);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	(void *)aJupe->next, (void *)aJupe->prev);
 
 		if (sentIdx >= endIdx)
 			break;

--- a/src/lang.c
+++ b/src/lang.c
@@ -583,12 +583,12 @@ unsigned long lang_mem_report(CSTR sourceNick, const User *callerUser) {
 	TRACE_FCLT(FACILITY_LANG_GET_STATS);
 
 	send_notice_to_user(sourceNick, callerUser, "\2Multi-language support\2:");
-	send_notice_to_user(sourceNick, callerUser, "Language loaded: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", lang_loaded_count, lang_memory_commit / 1024, lang_memory_commit);
+	send_notice_to_user(sourceNick, callerUser, "Language loaded: \2%u\2 -> \2%lu\2 KB (\2%lu\2 B)", lang_loaded_count, lang_memory_commit / 1024, lang_memory_commit);
 
 	for (i = 0; i < LANG_COUNT; i++) {
 
 		if (FlagSet(lang_tables[i].flags, LIF_LOADED))
-			send_notice_to_user(sourceNick, callerUser, "%d) %s : \2%d\2 KB (\2%d\2 B)", i + 1, lang_tables[i].lang_name_loc, lang_tables[i].memory_size / 1024, lang_tables[i].memory_size);
+			send_notice_to_user(sourceNick, callerUser, "%d) %s : \2%lu\2 KB (\2%lu\2 B)", i + 1, lang_tables[i].lang_name_loc, lang_tables[i].memory_size / 1024, lang_tables[i].memory_size);
 	}
 
 	return lang_memory_commit;
@@ -1132,7 +1132,7 @@ void lang_send_list(CSTR source, const User *dest) {
 
 		TRACE();
 		if (FlagSet(table->flags, LIF_LOADED | LIF_LOAD_DEFERRED))
-			send_notice_to_user(source, dest, "%d) %s (%s)", lang_id+1, table->lang_name_loc, table->lang_name_eng);
+			send_notice_to_user(source, dest, "%u) %s (%s)", lang_id+1, table->lang_name_loc, table->lang_name_eng);
 	}
 
 	send_notice_lang_to_user(source, dest, GetCallerLang(), END_OF_LIST);

--- a/src/lang.c
+++ b/src/lang.c
@@ -42,7 +42,7 @@ LANG_ID		current_caller_lang;
 * Local variables                                       *
 *********************************************************/
 
-#define CLNG_FILE_FORMAT	"lang/svc%d.clng"
+#define CLNG_FILE_FORMAT	"lang/svc%u.clng"
 
 // Tabella lingue
 
@@ -493,7 +493,7 @@ static BOOL lang_load(LANG_ID lang_id) {
 								}
 								else {
 
-									LOG_DEBUG_SNOOP("lang_load() invalid id! %d", msgheader.id);
+									LOG_DEBUG_SNOOP("lang_load() invalid id! %u", msgheader.id);
 									continue; // il messaggio non e' previsto, saltarlo
 								}
 							}
@@ -661,7 +661,7 @@ const LANG_MSG lang_msg(LANG_ID lang_id, LANG_MSG_ID msg_id) {
 	if ((msg_id < LANG_MSG_FIRST) || (msg_id > LANG_MSG_LAST)) {
 
 		log_error(FACILITY_LANG_MSG, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_PROPAGATED,
-			"lang_msg(): message ID %d for language %d (%s) is out of bounds", msg_id, lang_id, lang_get_name(lang_id, FALSE));
+			"lang_msg(): message ID %u for language %u (%s) is out of bounds", msg_id, lang_id, lang_get_name(lang_id, FALSE));
 
 		return lang_msg_not_valid;
 	}
@@ -671,7 +671,7 @@ const LANG_MSG lang_msg(LANG_ID lang_id, LANG_MSG_ID msg_id) {
 	if (IS_NULL(table)) {
 
 		log_error(FACILITY_LANG_MSG, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_PROPAGATED,
-			"lang_msg(): requested table for message ID %d in language %d (%s) is empty", msg_id, lang_id, lang_get_name(lang_id, FALSE));
+			"lang_msg(): requested table for message ID %u in language %u (%s) is empty", msg_id, lang_id, lang_get_name(lang_id, FALSE));
 
 		if (lang_id != LANG_DEFAULT)
 			return lang_msg(LANG_DEFAULT, msg_id);
@@ -689,7 +689,7 @@ const LANG_MSG lang_msg(LANG_ID lang_id, LANG_MSG_ID msg_id) {
 		if (FlagSet(table->flags, LIF_OFFLINE)) {
 
 			log_error(FACILITY_LANG_MSG, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_PROPAGATED,
-				"lang_msg(): requested table for message ID %d in language %d (%s) is offline", msg_id, lang_id, lang_get_name(lang_id, FALSE));
+				"lang_msg(): requested table for message ID %u in language %u (%s) is offline", msg_id, lang_id, lang_get_name(lang_id, FALSE));
 
 			if (lang_id != LANG_DEFAULT)
 				return lang_msg(LANG_DEFAULT, msg_id);
@@ -714,7 +714,7 @@ const LANG_MSG lang_msg(LANG_ID lang_id, LANG_MSG_ID msg_id) {
 		if (FlagUnset(table->flags, LIF_LOADED)) {
 
 			log_error(FACILITY_LANG_MSG, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_PROPAGATED,
-				"lang_msg(): requested table for message ID %d in language %d (%s) is not loaded", msg_id, lang_id, lang_get_name(lang_id, FALSE));
+				"lang_msg(): requested table for message ID %u in language %u (%s) is not loaded", msg_id, lang_id, lang_get_name(lang_id, FALSE));
 
 			return lang_not_loaded;
 		}
@@ -732,7 +732,7 @@ const LANG_MSG lang_msg(LANG_ID lang_id, LANG_MSG_ID msg_id) {
 		else {
 
 			log_error(FACILITY_LANG_MSG, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_PROPAGATED,
-				"lang_msg(): requested entry with message ID %d in language %d (%s) is empty", msg_id, lang_id, lang_get_name(lang_id, FALSE));
+				"lang_msg(): requested entry with message ID %u in language %u (%s) is empty", msg_id, lang_id, lang_get_name(lang_id, FALSE));
 
 			if (lang_id != LANG_DEFAULT)
 				return lang_msg(LANG_DEFAULT, msg_id);
@@ -743,7 +743,7 @@ const LANG_MSG lang_msg(LANG_ID lang_id, LANG_MSG_ID msg_id) {
 	else {
 
 		log_error(FACILITY_LANG_MSG, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_PROPAGATED,
-			"lang_msg(): requested language %d (%s) was not loaded (message ID: %d)", lang_id, lang_get_name(lang_id, FALSE), msg_id);
+			"lang_msg(): requested language %u (%s) was not loaded (message ID: %u)", lang_id, lang_get_name(lang_id, FALSE), msg_id);
 
 		if (lang_id != LANG_DEFAULT)
 			return lang_msg(LANG_DEFAULT, msg_id);
@@ -976,11 +976,11 @@ BOOL lang_reload(LANG_ID lang_id) {
 	TRACE_FCLT(FACILITY_LANG_RELOAD);
 
 	lang_name = lang_get_shortname(lang_id);
-	LOG_DEBUG_SNOOP("Reloading language \2%s\2 (%d) ...", lang_name, lang_id);
+	LOG_DEBUG_SNOOP("Reloading language \2%s\2 (%u) ...", lang_name, lang_id);
 
 	if (!lang_check_data_file(lang_id)) {
 
-		LOG_DEBUG_SNOOP("\2ERROR:\2 Invalid signature or file not found : \2%s\2 (%d). Reload interrupted.", lang_name, lang_id);
+		LOG_DEBUG_SNOOP("\2ERROR:\2 Invalid signature or file not found : \2%s\2 (%u). Reload interrupted.", lang_name, lang_id);
 		return FALSE;
 	}
 
@@ -992,14 +992,14 @@ BOOL lang_reload(LANG_ID lang_id) {
 
 		TRACE();
 		if (FlagSet(table->flags, LIF_LOADED)) {
-			LOG_DEBUG_SNOOP("Unloading language (\2%d\2 B) ...", table->memory_size);
+			LOG_DEBUG_SNOOP("Unloading language (\2%lu\2 B) ...", table->memory_size);
 			TRACE();
 			lang_unload(lang_id);
 		}
 
 		TRACE();
 		if (lang_load(lang_id)) {
-			LOG_DEBUG_SNOOP("Language loaded (\2%d\2 B)", table->memory_size);
+			LOG_DEBUG_SNOOP("Language loaded (\2%lu\2 B)", table->memory_size);
 			return TRUE;
 		} else {
 			LOG_DEBUG_SNOOP("Reload of language \2%s\2 failed: lang_load() failed!", lang_name);

--- a/src/logging.c
+++ b/src/logging.c
@@ -837,7 +837,7 @@ static BOOL log_search_file(CSTR agentNickname, const User *callerUser, int logT
 					if (line < startLine)
 						continue;
 					
-					send_notice_to_user(agentNickname, callerUser, "LOG(\2%d\2): %s", line, log_buffer);
+					send_notice_to_user(agentNickname, callerUser, "LOG(\2%lu\2): %s", line, log_buffer);
 
 					++count;
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -460,16 +460,15 @@ CSTR log_get_last_error_signature(void) {
 
 
 void log_debug(CSTR fmt, ...) {
+	if ((CONF_SET_DEBUG == TRUE) && IS_NOT_NULL(fmt) && (log_rotation_started == FALSE)) {
+		va_list		args;
 
-	/* Note: do *NOT* call this directly. Use the LOG_DEBUG() macro instead. */
+		va_start(args, fmt);
+		log_buffer[0] = c_NULL;
+		vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
 
-	va_list		args;
-
-	va_start(args, fmt);
-	log_buffer[0] = c_NULL;
-	vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
-
-	log_debug_direct(log_buffer);
+		log_debug_direct(log_buffer);
+	}
 }
 
 void log_debug_direct(CSTR string) {
@@ -563,29 +562,27 @@ void log_panic_direct(CSTR string) {
 
 
 void log_snoop(CSTR source, CSTR fmt, ...) {
+	if ((global_running == TRUE) && (CONF_SET_SNOOP == TRUE) && IS_NOT_NULL(fmt)) {
+		va_list		args;
 
-	/* Note: do *NOT* call this directly. Use the LOG_SNOOP() macro instead. */
+		log_buffer[0] = c_NULL;
+		va_start(args, fmt);
+		vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
 
-	va_list		args;
-
-	log_buffer[0] = c_NULL;
-	va_start(args, fmt);
-	vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
-
-	send_cmd(":%s PRIVMSG %s :%s", source, CONF_SNOOP_CHAN, log_buffer);
+		send_cmd(":%s PRIVMSG %s :%s", source, CONF_SNOOP_CHAN, log_buffer);
+	}
 }
 
 void log_debug_snoop(CSTR fmt, ...) {
+	if ((global_running == TRUE) && (CONF_SET_SNOOP == TRUE) && IS_NOT_NULL(fmt)) {
+		va_list		args;
 
-	/* Note: do *NOT* call this directly. Use the LOG_DEBUG_SNOOP() macro instead. */
+		log_buffer[0] = c_NULL;
+		va_start(args, fmt);
+		vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
 
-	va_list		args;
-
-	log_buffer[0] = c_NULL;
-	va_start(args, fmt);
-	vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
-
-	send_cmd(":%s PRIVMSG %s :%s", s_DebugServ, CONF_DEBUG_CHAN, log_buffer);
+		send_cmd(":%s PRIVMSG %s :%s", s_DebugServ, CONF_DEBUG_CHAN, log_buffer);
+	}
 }
 
 void log_stderr(CSTR fmt, ...) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -410,13 +410,14 @@ void log_error(FACILITY facility, FACILITY_LINE line, LOG_TYPE type, SEVERITY se
 		size_t		len;
 
 
-		va_start(args, fmt);
 		snprintf(log_buffer, sizeof(log_buffer), "%s %s ", log_get_timestamp(0), log_get_signature(facility, line, type, severity));
 
 		len = str_len(log_buffer);
 		ptr = log_buffer + len;
 
+		va_start(args, fmt);
 		vsnprintf(ptr, sizeof(log_buffer) - len, fmt, args);
+		va_end(args);
 
 		fputs(log_buffer, log_files[LOG_GENERAL_ERRORS].file);
 		fputc(c_LF, log_files[LOG_GENERAL_ERRORS].file);
@@ -466,6 +467,7 @@ void log_debug(CSTR fmt, ...) {
 		va_start(args, fmt);
 		log_buffer[0] = c_NULL;
 		vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
+		va_end(args);
 
 		log_debug_direct(log_buffer);
 	}
@@ -526,11 +528,12 @@ void log_services(int services, CSTR fmt, ...) {
 		size_t		len;
 
 
-		va_start(args, fmt);
 		log_buffer[0] = c_NULL;
 		snprintf(log_buffer, sizeof(log_buffer), "%s ", log_get_timestamp(0));
 		len = str_len(log_buffer);
+		va_start(args, fmt);
 		vsnprintf(log_buffer + len, sizeof(log_buffer) - len, fmt, args);
+		va_end(args);
 
 		fputs(log_buffer, log_files[services].file);
 		fputc(c_LF, log_files[services].file);
@@ -546,6 +549,7 @@ void log_panic(CSTR fmt, ...) {
 
 		va_start(args, fmt);
 		vfprintf(log_files[LOG_GENERAL_PANIC].file, fmt, args);
+		va_end(args);
 		fputc(c_LF, log_files[LOG_GENERAL_PANIC].file);
 	}
 }
@@ -567,6 +571,7 @@ void log_snoop(CSTR source, CSTR fmt, ...) {
 		log_buffer[0] = c_NULL;
 		va_start(args, fmt);
 		vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
+		va_end(args);
 
 		send_cmd(":%s PRIVMSG %s :%s", source, CONF_SNOOP_CHAN, log_buffer);
 	}
@@ -579,6 +584,7 @@ void log_debug_snoop(CSTR fmt, ...) {
 		log_buffer[0] = c_NULL;
 		va_start(args, fmt);
 		vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
+		va_end(args);
 
 		send_cmd(":%s PRIVMSG %s :%s", s_DebugServ, CONF_DEBUG_CHAN, log_buffer);
 	}
@@ -593,6 +599,7 @@ void log_stderr(CSTR fmt, ...) {
 		log_buffer[0] = c_NULL;
 		va_start(args, fmt);
 		vsnprintf(log_buffer, sizeof(log_buffer), fmt, args);
+		va_end(args);
 
 		// send the message on the debug snoop channel ...
 		if (global_running)
@@ -610,14 +617,13 @@ void fatal_error(FACILITY facility, FACILITY_LINE line, CSTR fmt, ...) {
 	va_list args;
 
 
-	va_start(args, fmt);
 
 	lang_format_localtime(timebuf, sizeof(timebuf), LANG_DEFAULT, TIME_FORMAT_FULLDATE, NOW);
 
 	len = str_copy_checked("FATAL ERROR: ", buffer, sizeof(buffer));
 
+	va_start(args, fmt);
 	vsnprintf(buffer + len, sizeof(buffer) - len, fmt, args);
-
 	va_end(args);
 
 	/* Log to appropriate log file, also sends to console. */

--- a/src/logging.c
+++ b/src/logging.c
@@ -153,7 +153,7 @@ static STDSTR log_get_signature(FACILITY facility, FACILITY_LINE line, LOG_TYPE 
 
 	static char		signature[32];
 
-	snprintf(signature, sizeof(signature), "[F%05d L%05d T%03d S%03d]", facility, line, type, severity);
+	snprintf(signature, sizeof(signature), "[F%05d L%05u T%03d S%03d]", facility, line, type, severity);
 	return (STDSTR) signature;
 }
 
@@ -237,7 +237,7 @@ CSTR log_get_trace_string(FACILITY main_facility, FACILITY_LINE main_line, FACIL
 
 	static char		trace_string[64];
 
-	snprintf(trace_string, sizeof(trace_string), "E%d MF%d ML%d CF%d CL%d", TRACE_ENABLED, main_facility, main_line, current_facility, current_line);
+	snprintf(trace_string, sizeof(trace_string), "E%d MF%d ML%u CF%d CL%u", TRACE_ENABLED, main_facility, main_line, current_facility, current_line);
 	return (CSTR) trace_string;
 }
 
@@ -403,7 +403,7 @@ void log_rotate(BOOL force) {
 
 void log_error(FACILITY facility, FACILITY_LINE line, LOG_TYPE type, SEVERITY severity, CSTR fmt, ...) {
 
-	if (IS_NOT_NULL(fmt) && !log_rotation_started) {
+	if (!log_rotation_started) {
 
 		va_list		args;
 		STR			ptr;
@@ -460,7 +460,7 @@ CSTR log_get_last_error_signature(void) {
 
 
 void log_debug(CSTR fmt, ...) {
-	if ((CONF_SET_DEBUG == TRUE) && IS_NOT_NULL(fmt) && (log_rotation_started == FALSE)) {
+	if ((CONF_SET_DEBUG == TRUE) && (log_rotation_started == FALSE)) {
 		va_list		args;
 
 		va_start(args, fmt);
@@ -518,8 +518,7 @@ int logid_from_agentid(agentid_t agentID) {
 
 void log_services(int services, CSTR fmt, ...) {
 
-	if (IS_NOT_NULL(fmt) &&
-		(services >= LOG_SERVICES_NICKSERV_GENERAL && services <= LOG_SERVICES_SEENSERV)
+	if ((services >= LOG_SERVICES_NICKSERV_GENERAL && services <= LOG_SERVICES_SEENSERV)
 		&& !log_rotation_started
 		) {
 
@@ -541,7 +540,7 @@ void log_services(int services, CSTR fmt, ...) {
 
 void log_panic(CSTR fmt, ...) {
 
-	if (IS_NOT_NULL(fmt) && !log_rotation_started) {
+	if (!log_rotation_started) {
 
 		va_list		args;
 
@@ -562,7 +561,7 @@ void log_panic_direct(CSTR string) {
 
 
 void log_snoop(CSTR source, CSTR fmt, ...) {
-	if ((global_running == TRUE) && (CONF_SET_SNOOP == TRUE) && IS_NOT_NULL(fmt)) {
+	if ((global_running == TRUE) && (CONF_SET_SNOOP == TRUE)) {
 		va_list		args;
 
 		log_buffer[0] = c_NULL;
@@ -574,7 +573,7 @@ void log_snoop(CSTR source, CSTR fmt, ...) {
 }
 
 void log_debug_snoop(CSTR fmt, ...) {
-	if ((global_running == TRUE) && (CONF_SET_SNOOP == TRUE) && IS_NOT_NULL(fmt)) {
+	if ((global_running == TRUE) && (CONF_SET_SNOOP == TRUE)) {
 		va_list		args;
 
 		log_buffer[0] = c_NULL;
@@ -587,7 +586,7 @@ void log_debug_snoop(CSTR fmt, ...) {
 
 void log_stderr(CSTR fmt, ...) {
 
-	if (IS_NOT_NULL(fmt) && !log_rotation_started) {
+	if (!log_rotation_started) {
 
 		va_list		args;
 
@@ -1065,7 +1064,7 @@ void handle_search(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 	// Ricerca
 	TRACE();
-	LOG_DEBUG_SNOOP("Command: LOG SEARCH %s %s \2%s\2 %d %d -- by %s (%s@%s)", type, days, search, start_line, end_line, callerUser->nick, callerUser->username, callerUser->host);
+	LOG_DEBUG_SNOOP("Command: LOG SEARCH %s %s \2%s\2 %lu %lu -- by %s (%s@%s)", type, days, search, start_line, end_line, callerUser->nick, callerUser->username, callerUser->host);
 	log_search_file(data->agent->nick, callerUser, log_type, days, search, start_line, end_line);
 
 	TRACE();

--- a/src/logging.c
+++ b/src/logging.c
@@ -618,8 +618,11 @@ void fatal_error(FACILITY facility, FACILITY_LINE line, CSTR fmt, ...) {
 
 	vsnprintf(buffer + len, sizeof(buffer) - len, fmt, args);
 
+	va_end(args);
+
 	/* Log to appropriate log file, also sends to console. */
-	log_error(facility, line, LOG_TYPE_ERROR_FATAL, LOG_SEVERITY_ERROR_QUIT, buffer);
+	/* While this seems pointless after a vsnprintf call, buffer contents *MIGHT* contain valid format specifiers, let's guard against that! */
+	log_error(facility, line, LOG_TYPE_ERROR_FATAL, LOG_SEVERITY_ERROR_QUIT, "%s", buffer);
 
 	/* Send a globop if we're still connected. */
 	if (global_running)

--- a/src/main.c
+++ b/src/main.c
@@ -484,9 +484,9 @@ static void timeout_check_handler(int sig_unused) {
 void database_expire(const time_t now) {
 
 	if (CONF_DISPLAY_UPDATES)
-		send_globops(NULL, "Running Database Store & Expire #%d", expire_count);
+		send_globops(NULL, "Running Database Store & Expire #%lu", expire_count);
 	else
-		LOG_SNOOP(s_OperServ, "Running Database Store & Expire #%d", expire_count);
+		LOG_SNOOP(s_OperServ, "Running Database Store & Expire #%lu", expire_count);
 
 	++expire_count;
 

--- a/src/main.c
+++ b/src/main.c
@@ -376,7 +376,7 @@ static BOOL initialize() {
 
 	send_cmd("PASS %s :TS", CONF_REMOTE_PASSWORD);
 	send_cmd("SVINFO 5 3 0 :%ld", time(NULL));
-	send_cmd(CAPAB);
+	send_cmd("%s", CAPAB);
 	send_cmd("SERVER %s 1 :%s", CONF_SERVICES_NAME, CONF_SERVICES_DESC);
 
 	TRACE_MAIN();

--- a/src/memory.c
+++ b/src/memory.c
@@ -51,7 +51,7 @@ void *mem_malloc(size_t size) {
 	if (IS_NULL(buffer)) {
 
 		log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_QUIT,
-			"mem_malloc(): Out of memory on a %lu byte request.", size);
+			"mem_malloc(): Out of memory on a %zu byte request.", size);
 
 		raise(SIG_OUT_OF_MEMORY);
 	}
@@ -80,7 +80,7 @@ void *mem_calloc(size_t count, size_t size) {
 	if (IS_NULL(buffer)) {
 
 		log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_QUIT,
-			"mem_calloc(): Out of memory on a %lu byte request.", size * count);
+			"mem_calloc(): Out of memory on a %zu byte request.", size * count);
 
 		raise(SIG_OUT_OF_MEMORY);
 	}
@@ -101,7 +101,7 @@ void *mem_realloc(void *ptr, size_t size) {
 	if (IS_NULL(buffer) && (size != 0)) {
 
 		log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_QUIT,
-			"mem_realloc(): Out of memory on a %lu byte request.", size);
+			"mem_realloc(): Out of memory on a %zu byte request.", size);
 
 		raise(SIG_OUT_OF_MEMORY);
 	}

--- a/src/memory.c
+++ b/src/memory.c
@@ -51,7 +51,7 @@ void *mem_malloc(size_t size) {
 	if (IS_NULL(buffer)) {
 
 		log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_QUIT,
-			"mem_malloc(): Out of memory on a %d byte request.", size);
+			"mem_malloc(): Out of memory on a %lu byte request.", size);
 
 		raise(SIG_OUT_OF_MEMORY);
 	}
@@ -80,7 +80,7 @@ void *mem_calloc(size_t count, size_t size) {
 	if (IS_NULL(buffer)) {
 
 		log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_QUIT,
-			"mem_calloc(): Out of memory on a %d byte request.", size * count);
+			"mem_calloc(): Out of memory on a %lu byte request.", size * count);
 
 		raise(SIG_OUT_OF_MEMORY);
 	}
@@ -101,7 +101,7 @@ void *mem_realloc(void *ptr, size_t size) {
 	if (IS_NULL(buffer) && (size != 0)) {
 
 		log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_QUIT,
-			"mem_realloc(): Out of memory on a %d byte request.", size);
+			"mem_realloc(): Out of memory on a %lu byte request.", size);
 
 		raise(SIG_OUT_OF_MEMORY);
 	}
@@ -382,7 +382,7 @@ void mempool_free(MemoryPool *mp, void *mem) {
 				map_region_offset = map_region_offset / MP_MAP_REGION_SIZE;
 
 				if ((ptr->allocation_map[map_region_offset] & map_region_mask) == 0) {
-					log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_WARNING, "mempool_free(): block already free! [PoolID: %d | ptr: 0x%X]", mp->id, mem);
+					log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_WARNING, "mempool_free(): block already free! [PoolID: %u | ptr: %p]", mp->id, mem);
 
 				} else {
 
@@ -431,7 +431,7 @@ void mempool_free2(MemoryPool *mp, void *mem, MEMORYBLOCK_ID mblock_id) {
 				map_region_offset = bd->offset;
 */
 				if ((ptr->allocation_map[map_region_offset] & map_region_mask) == 0) {
-					log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_WARNING, "mempool_free(): block already free! [PoolID: %d | ptr: 0x%X]", mp->id, mem);
+					log_error(FACILITY_MEMORY, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_WARNING, "mempool_free(): block already free! [PoolID: %u | ptr: %p]", mp->id, mem);
 
 				} else {
 

--- a/src/memoserv.c
+++ b/src/memoserv.c
@@ -3160,11 +3160,11 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					for (memo = ml->memos, memoIdx = 0; memoIdx < ml->n_memos; ++memoIdx, ++memo) {
 
-						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",			(memoIdx + 1), memo, sizeof(Memo));
+						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",			(memoIdx + 1), (void *)memo, sizeof(Memo));
 						send_notice_to_user(sourceNick, callerUser, "Unused: %ld / Time Sent C-time: %ld",	memo->unused, memo->time);
 						send_notice_to_user(sourceNick, callerUser, "Sent by: %s / Flags: %d",				memo->sender, memo->flags);
-						send_notice_to_user(sourceNick, callerUser, "Channel: %p \2[\2%s\2]\2",				memo->chan, str_get_valid_display_value(memo->chan));
-						send_notice_to_user(sourceNick, callerUser, "Text: %p \2[\2%s\2]\2",				memo->text, str_get_valid_display_value(memo->text));
+						send_notice_to_user(sourceNick, callerUser, "Channel: %p \2[\2%s\2]\2",				(void *)memo->chan, str_get_valid_display_value(memo->chan));
+						send_notice_to_user(sourceNick, callerUser, "Text: %p \2[\2%s\2]\2",				(void *)memo->text, str_get_valid_display_value(memo->text));
 						send_notice_to_user(sourceNick, callerUser, "Level: %d",							memo->level);
 						send_notice_to_user(sourceNick, callerUser, "reserved[3]: %ld %ld %ld",				memo->reserved[0], memo->reserved[1], memo->reserved[2]);
 					}
@@ -3180,10 +3180,10 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					for (ignore = ml->ignores; IS_NOT_NULL(ignore); ignore = ignore->next) {
 
 						++idx;
-						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",		idx, ignore, sizeof(MemoIgnore));
-						send_notice_to_user(sourceNick, callerUser, "Ignored Nick: %p \2[\2%s\2]\2",	ignore->ignoredNick, str_get_valid_display_value(ignore->ignoredNick));
+						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",		idx, (void *)ignore, sizeof(MemoIgnore));
+						send_notice_to_user(sourceNick, callerUser, "Ignored Nick: %p \2[\2%s\2]\2",	(void *)ignore->ignoredNick, str_get_valid_display_value(ignore->ignoredNick));
 						send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",			ignore->creationTime);
-						send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	ignore->next, ignore->prev);
+						send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	(void *)ignore->next, (void *)ignore->prev);
 					}
 
 					LOG_DEBUG_SNOOP("Command: DUMP MEMOSERV NICK %s -- by %s (%s@%s) [Ignores]", value, callerUser->nick, callerUser->username, callerUser->host);
@@ -3192,14 +3192,14 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: memolist for \2%s\2", value);
 
-					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			ml, sizeof(MemoList));
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			(void *)ml, sizeof(MemoList));
 					send_notice_to_user(sourceNick, callerUser, "Name: %s",							ml->nick);
-					send_notice_to_user(sourceNick, callerUser, "Memos: %p",						ml->memos);
+					send_notice_to_user(sourceNick, callerUser, "Memos: %p",						(void *)ml->memos);
 					send_notice_to_user(sourceNick, callerUser, "Number of Memos: %ld",				ml->n_memos);
-					send_notice_to_user(sourceNick, callerUser, "Ignores: %p",						ml->ignores);
+					send_notice_to_user(sourceNick, callerUser, "Ignores: %p",						(void *)ml->ignores);
 					send_notice_to_user(sourceNick, callerUser, "Number of Ignores: %ld",			ml->n_ignores);
 					send_notice_to_user(sourceNick, callerUser, "reserved[2]: %ld %ld",				ml->reserved[0], ml->reserved[1]);
-					send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	ml->next, ml->prev);
+					send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	(void *)ml->next, (void *)ml->prev);
 
 					LOG_DEBUG_SNOOP("Command: DUMP MEMOSERV NICK %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -3213,7 +3213,7 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			MemoryPoolStats pstats;
 
 			mempool_stats(memodb_mempool, &pstats);
-			send_notice_to_user(sourceNick, callerUser, "DUMP: MemoServ memory pool - Address %p, ID: %u",	memodb_mempool, pstats.id);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: MemoServ memory pool - Address %p, ID: %u",	(void *)memodb_mempool, pstats.id);
 			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",			pstats.memory_allocated, pstats.memory_free);
 			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",				pstats.items_allocated, pstats.items_free);
 			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",			pstats.items_per_block, pstats.block_count);

--- a/src/memoserv.c
+++ b/src/memoserv.c
@@ -2993,7 +2993,7 @@ static void do_info(const char *source, User *callerUser, ServiceCommandData *da
 	}
 
 	send_notice_lang_to_user(s_MemoServ, callerUser, GetCallerLang(), MS_INFO_HEADER, ni->nick);
-	send_notice_to_user(s_MemoServ, callerUser, s_SPACE);
+	send_notice_to_user(s_MemoServ, callerUser, " ");
 
 	TRACE_MAIN();
 	if (IS_NULL(ml = find_memolist(nick)))
@@ -3050,7 +3050,7 @@ static void do_info(const char *source, User *callerUser, ServiceCommandData *da
 					send_notice_lang_to_user(s_MemoServ, callerUser, GetCallerLang(), MS_READ_MEMO_MESSAGE, memo->text);
 			}
 
-			send_notice_to_user(s_MemoServ, callerUser, s_SPACE);
+			send_notice_to_user(s_MemoServ, callerUser, " ");
 			send_notice_lang_to_user(s_MemoServ, callerUser, GetCallerLang(), END_OF_INFO);
 			return;
 		}
@@ -3120,7 +3120,7 @@ static void do_info(const char *source, User *callerUser, ServiceCommandData *da
 	if (FlagSet(ni->flags, NI_EMAILMEMOS) && ni->email)
 		send_notice_lang_to_user(s_MemoServ, callerUser, GetCallerLang(), MS_INFO_EMAILMEMOS_ON, ni->email);
 
-	send_notice_to_user(s_MemoServ, callerUser, s_SPACE);
+	send_notice_to_user(s_MemoServ, callerUser, " ");
 	send_notice_lang_to_user(s_MemoServ, callerUser, GetCallerLang(), END_OF_INFO);
 }
 
@@ -3160,13 +3160,13 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					for (memo = ml->memos, memoIdx = 0; memoIdx < ml->n_memos; ++memoIdx, ++memo) {
 
-						send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",			(memoIdx + 1), (unsigned long)memo, sizeof(Memo));
-						send_notice_to_user(sourceNick, callerUser, "Unused: %d / Time Sent C-time: %d",		memo->unused, memo->time);
-						send_notice_to_user(sourceNick, callerUser, "Sent by: %s / Flags: %d",					memo->sender, memo->flags);
-						send_notice_to_user(sourceNick, callerUser, "Channel: 0x%08X \2[\2%s\2]\2",				(unsigned long)memo->chan, str_get_valid_display_value(memo->chan));
-						send_notice_to_user(sourceNick, callerUser, "Text: 0x%08X \2[\2%s\2]\2",				(unsigned long)memo->text, str_get_valid_display_value(memo->text));
-						send_notice_to_user(sourceNick, callerUser, "Level: %d",								memo->level);
-						send_notice_to_user(sourceNick, callerUser, "reserved[3]: %d %d %d",					memo->reserved[0], memo->reserved[1], memo->reserved[2]);
+						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",			(memoIdx + 1), memo, sizeof(Memo));
+						send_notice_to_user(sourceNick, callerUser, "Unused: %ld / Time Sent C-time: %ld",	memo->unused, memo->time);
+						send_notice_to_user(sourceNick, callerUser, "Sent by: %s / Flags: %d",				memo->sender, memo->flags);
+						send_notice_to_user(sourceNick, callerUser, "Channel: %p \2[\2%s\2]\2",				memo->chan, str_get_valid_display_value(memo->chan));
+						send_notice_to_user(sourceNick, callerUser, "Text: %p \2[\2%s\2]\2",				memo->text, str_get_valid_display_value(memo->text));
+						send_notice_to_user(sourceNick, callerUser, "Level: %d",							memo->level);
+						send_notice_to_user(sourceNick, callerUser, "reserved[3]: %ld %ld %ld",				memo->reserved[0], memo->reserved[1], memo->reserved[2]);
 					}
 					LOG_DEBUG_SNOOP("Command: DUMP MEMOSERV NICK %s -- by %s (%s@%s) [Memos]", value, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -3180,10 +3180,10 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					for (ignore = ml->ignores; IS_NOT_NULL(ignore); ignore = ignore->next) {
 
 						++idx;
-						send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",			idx, (unsigned long)ignore, sizeof(MemoIgnore));
-						send_notice_to_user(sourceNick, callerUser, "Ignored Nick: 0x%08X \2[\2%s\2]\2",		(unsigned long)ignore->ignoredNick, str_get_valid_display_value(ignore->ignoredNick));
-						send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %d",					ignore->creationTime);
-						send_notice_to_user(sourceNick, callerUser, "Next / previous record: 0x%08X / 0x%08X",	(unsigned long)ignore->next, (unsigned long)ignore->prev);
+						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",		idx, ignore, sizeof(MemoIgnore));
+						send_notice_to_user(sourceNick, callerUser, "Ignored Nick: %p \2[\2%s\2]\2",	ignore->ignoredNick, str_get_valid_display_value(ignore->ignoredNick));
+						send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",			ignore->creationTime);
+						send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	ignore->next, ignore->prev);
 					}
 
 					LOG_DEBUG_SNOOP("Command: DUMP MEMOSERV NICK %s -- by %s (%s@%s) [Ignores]", value, callerUser->nick, callerUser->username, callerUser->host);
@@ -3192,14 +3192,14 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: memolist for \2%s\2", value);
 
-					send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",					(unsigned long)ml, sizeof(MemoList));
-					send_notice_to_user(sourceNick, callerUser, "Name: %s",										ml->nick);
-					send_notice_to_user(sourceNick, callerUser, "Memos: 0x%08X",								(unsigned long)ml->memos);
-					send_notice_to_user(sourceNick, callerUser, "Number of Memos: %d",							ml->n_memos);
-					send_notice_to_user(sourceNick, callerUser, "Ignores: 0x%08X",								(unsigned long)ml->ignores);
-					send_notice_to_user(sourceNick, callerUser, "Number of Ignores: %d",						ml->n_ignores);
-					send_notice_to_user(sourceNick, callerUser, "reserved[2]: %d %d",							ml->reserved[0], ml->reserved[1]);
-					send_notice_to_user(sourceNick, callerUser, "Next / previous record: 0x%08X / 0x%08X",		(unsigned long)ml->next, (unsigned long)ml->prev);
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			ml, sizeof(MemoList));
+					send_notice_to_user(sourceNick, callerUser, "Name: %s",							ml->nick);
+					send_notice_to_user(sourceNick, callerUser, "Memos: %p",						ml->memos);
+					send_notice_to_user(sourceNick, callerUser, "Number of Memos: %ld",				ml->n_memos);
+					send_notice_to_user(sourceNick, callerUser, "Ignores: %p",						ml->ignores);
+					send_notice_to_user(sourceNick, callerUser, "Number of Ignores: %ld",			ml->n_ignores);
+					send_notice_to_user(sourceNick, callerUser, "reserved[2]: %ld %ld",				ml->reserved[0], ml->reserved[1]);
+					send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	ml->next, ml->prev);
 
 					LOG_DEBUG_SNOOP("Command: DUMP MEMOSERV NICK %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -3213,10 +3213,10 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			MemoryPoolStats pstats;
 
 			mempool_stats(memodb_mempool, &pstats);
-			send_notice_to_user(sourceNick, callerUser, "DUMP: MemoServ memory pool - Address 0x%08X, ID: %d",	(unsigned long)memodb_mempool, pstats.id);
-			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %d B / %d B",				pstats.memory_allocated, pstats.memory_free);
-			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %d / %d",					pstats.items_allocated, pstats.items_free);
-			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %d / %d",			pstats.items_per_block, pstats.block_count);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: MemoServ memory pool - Address %p, ID: %u",	memodb_mempool, pstats.id);
+			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",			pstats.memory_allocated, pstats.memory_free);
+			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",				pstats.items_allocated, pstats.items_free);
+			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",			pstats.items_per_block, pstats.block_count);
 			//send_notice_to_user(sourceNick, callerUser, "Average use: %.2f%%",								pstats.block_avg_usage);
 
 		#endif
@@ -3274,6 +3274,6 @@ unsigned long memoserv_mem_report(CSTR sourceNick, const User *callerUser) {
 		}
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Record / Memos: \2%d\2 / \2%d\2 -> \2%d\2 KB (\2%d\2 B)", recordCount, memoCount, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Record / Memos: \2%lu\2 / \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", recordCount, memoCount, mem / 1024, mem);
 	return mem;
 }

--- a/src/memoserv.c
+++ b/src/memoserv.c
@@ -545,7 +545,7 @@ void expire_memos() {
 	}
 
 	if (CONF_DISPLAY_UPDATES)
-		send_globops(NULL, "Completed MemoServ Expire: (%d/%d) Record Expire: (%d/%d)", expiredMemoCount, memoCount, expiredRecordCount, recordCount);
+		send_globops(NULL, "Completed MemoServ Expire: (%lu/%lu) Record Expire: (%lu/%lu)", expiredMemoCount, memoCount, expiredRecordCount, recordCount);
 	else
 		LOG_SNOOP(s_OperServ, "Completed MemoServ Expire: (%lu/%lu) Record Expire: (%lu/%lu)", expiredMemoCount, memoCount, expiredRecordCount, recordCount);
 }
@@ -2961,14 +2961,14 @@ static void do_info(const char *source, User *callerUser, ServiceCommandData *da
 
 		if (data->operMatch) {
 
-			send_globops(s_MemoServ, "\2%s\2 requested Memo Information on nick \2%s\2 [ Reading Memo number \2%d\2 ]", source, ni->nick, value);
+			send_globops(s_MemoServ, "\2%s\2 requested Memo Information on nick \2%s\2 [ Reading Memo number \2%ld\2 ]", source, ni->nick, value);
 
 			LOG_SNOOP(s_OperServ, "MS M %s -- by %s (%s@%s) [Reading Memo #%ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, value);
 			log_services(LOG_SERVICES_MEMOSERV, "M %s -- by %s (%s@%s) [Reading Memo #%ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, value);
 		}
 		else {
 
-			send_globops(s_MemoServ, "\2%s\2 (through \2%s\2) requested Memo Information on nick \2%s\2 [ Reading Memo number \2%d\2 ]", source, data->operName, ni->nick, value);
+			send_globops(s_MemoServ, "\2%s\2 (through \2%s\2) requested Memo Information on nick \2%s\2 [ Reading Memo number \2%ld\2 ]", source, data->operName, ni->nick, value);
 
 			LOG_SNOOP(s_OperServ, "MS M %s -- by %s (%s@%s) through %s [Reading Memo #%ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
 			log_services(LOG_SERVICES_MEMOSERV, "M %s -- by %s (%s@%s) through %s [Reading Memo #%ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, value);

--- a/src/memoserv.c
+++ b/src/memoserv.c
@@ -547,7 +547,7 @@ void expire_memos() {
 	if (CONF_DISPLAY_UPDATES)
 		send_globops(NULL, "Completed MemoServ Expire: (%d/%d) Record Expire: (%d/%d)", expiredMemoCount, memoCount, expiredRecordCount, recordCount);
 	else
-		LOG_SNOOP(s_OperServ, "Completed MemoServ Expire: (%d/%d) Record Expire: (%d/%d)", expiredMemoCount, memoCount, expiredRecordCount, recordCount);
+		LOG_SNOOP(s_OperServ, "Completed MemoServ Expire: (%lu/%lu) Record Expire: (%lu/%lu)", expiredMemoCount, memoCount, expiredRecordCount, recordCount);
 }
 
 
@@ -2008,9 +2008,9 @@ static void do_del(const char *source, User *callerUser, ServiceCommandData *dat
 					send_notice_lang_to_user(s_MemoServ, callerUser, GetCallerLang(), MS_DEL_MEMO_MARKED_DEL, value);
 
 					if (CONF_SET_EXTRASNOOP)
-						LOG_SNOOP(s_OperServ, "MS D %d -- by %s (%s@%s) [Message: %s ]", value, callerUser->nick, callerUser->username, callerUser->host, memo->text);
+						LOG_SNOOP(s_OperServ, "MS D %ld -- by %s (%s@%s) [Message: %s ]", value, callerUser->nick, callerUser->username, callerUser->host, memo->text);
 
-					log_services(LOG_SERVICES_MEMOSERV, "D %d -- by %s (%s@%s) [Message: %s ]", value, callerUser->nick, callerUser->username, callerUser->host, memo->text);
+					log_services(LOG_SERVICES_MEMOSERV, "D %ld -- by %s (%s@%s) [Message: %s ]", value, callerUser->nick, callerUser->username, callerUser->host, memo->text);
 				}
 			}
 			else
@@ -2255,9 +2255,9 @@ static void do_undel(const char *source, User *callerUser, ServiceCommandData *d
 					send_notice_lang_to_user(s_MemoServ, callerUser, GetCallerLang(), MS_UNDEL_MEMO_UNMARKED, value);
 
 					if (CONF_SET_EXTRASNOOP)
-						LOG_SNOOP(s_OperServ, "MS UD %d -- by %s (%s@%s) [Message: %s ]", value, callerUser->nick, callerUser->username, callerUser->host, memo->text);
+						LOG_SNOOP(s_OperServ, "MS UD %ld -- by %s (%s@%s) [Message: %s ]", value, callerUser->nick, callerUser->username, callerUser->host, memo->text);
 
-					log_services(LOG_SERVICES_MEMOSERV, "UD %d -- by %s (%s@%s) [Message: %s ]", value, callerUser->nick, callerUser->username, callerUser->host, memo->text);
+					log_services(LOG_SERVICES_MEMOSERV, "UD %ld -- by %s (%s@%s) [Message: %s ]", value, callerUser->nick, callerUser->username, callerUser->host, memo->text);
 				}
 				else
 					send_notice_lang_to_user(s_MemoServ, callerUser, GetCallerLang(), MS_UNDEL_ERROR_MEMO_NOT_MARKED, value);
@@ -2727,9 +2727,9 @@ static void do_ignore(const char *source, User *callerUser, ServiceCommandData *
 			send_notice_lang_to_user(s_MemoServ, callerUser, GetCallerLang(), WARNING_READONLY);
 
 		if (CONF_SET_EXTRASNOOP)
-			LOG_SNOOP(s_OperServ, "MS I! -- by %s (%s@%s) [Entries: %d ]", callerUser->nick, callerUser->username, callerUser->host, ml->n_ignores);
+			LOG_SNOOP(s_OperServ, "MS I! -- by %s (%s@%s) [Entries: %ld ]", callerUser->nick, callerUser->username, callerUser->host, ml->n_ignores);
 
-		log_services(LOG_SERVICES_MEMOSERV, "I! -- by %s (%s@%s) [Entries: %d ]", callerUser->nick, callerUser->username, callerUser->host, ml->n_ignores);
+		log_services(LOG_SERVICES_MEMOSERV, "I! -- by %s (%s@%s) [Entries: %ld ]", callerUser->nick, callerUser->username, callerUser->host, ml->n_ignores);
 
 		ml->ignores = NULL;
 		ml->n_ignores = 0;
@@ -2963,15 +2963,15 @@ static void do_info(const char *source, User *callerUser, ServiceCommandData *da
 
 			send_globops(s_MemoServ, "\2%s\2 requested Memo Information on nick \2%s\2 [ Reading Memo number \2%d\2 ]", source, ni->nick, value);
 
-			LOG_SNOOP(s_OperServ, "MS M %s -- by %s (%s@%s) [Reading Memo #%d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, value);
-			log_services(LOG_SERVICES_MEMOSERV, "M %s -- by %s (%s@%s) [Reading Memo #%d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, value);
+			LOG_SNOOP(s_OperServ, "MS M %s -- by %s (%s@%s) [Reading Memo #%ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, value);
+			log_services(LOG_SERVICES_MEMOSERV, "M %s -- by %s (%s@%s) [Reading Memo #%ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, value);
 		}
 		else {
 
 			send_globops(s_MemoServ, "\2%s\2 (through \2%s\2) requested Memo Information on nick \2%s\2 [ Reading Memo number \2%d\2 ]", source, data->operName, ni->nick, value);
 
-			LOG_SNOOP(s_OperServ, "MS M %s -- by %s (%s@%s) through %s [Reading Memo #%d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
-			log_services(LOG_SERVICES_MEMOSERV, "M %s -- by %s (%s@%s) through %s [Reading Memo #%d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
+			LOG_SNOOP(s_OperServ, "MS M %s -- by %s (%s@%s) through %s [Reading Memo #%ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
+			log_services(LOG_SERVICES_MEMOSERV, "M %s -- by %s (%s@%s) through %s [Reading Memo #%ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
 		}
 	}
 	else {

--- a/src/memoserv.c
+++ b/src/memoserv.c
@@ -3160,7 +3160,7 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					for (memo = ml->memos, memoIdx = 0; memoIdx < ml->n_memos; ++memoIdx, ++memo) {
 
-						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",			(memoIdx + 1), (void *)memo, sizeof(Memo));
+						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",			(memoIdx + 1), (void *)memo, sizeof(Memo));
 						send_notice_to_user(sourceNick, callerUser, "Unused: %ld / Time Sent C-time: %ld",	memo->unused, memo->time);
 						send_notice_to_user(sourceNick, callerUser, "Sent by: %s / Flags: %d",				memo->sender, memo->flags);
 						send_notice_to_user(sourceNick, callerUser, "Channel: %p \2[\2%s\2]\2",				(void *)memo->chan, str_get_valid_display_value(memo->chan));
@@ -3180,7 +3180,7 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					for (ignore = ml->ignores; IS_NOT_NULL(ignore); ignore = ignore->next) {
 
 						++idx;
-						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",		idx, (void *)ignore, sizeof(MemoIgnore));
+						send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",		idx, (void *)ignore, sizeof(MemoIgnore));
 						send_notice_to_user(sourceNick, callerUser, "Ignored Nick: %p \2[\2%s\2]\2",	(void *)ignore->ignoredNick, str_get_valid_display_value(ignore->ignoredNick));
 						send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",			ignore->creationTime);
 						send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	(void *)ignore->next, (void *)ignore->prev);
@@ -3192,7 +3192,7 @@ void memoserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: memolist for \2%s\2", value);
 
-					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			(void *)ml, sizeof(MemoList));
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",			(void *)ml, sizeof(MemoList));
 					send_notice_to_user(sourceNick, callerUser, "Name: %s",							ml->nick);
 					send_notice_to_user(sourceNick, callerUser, "Memos: %p",						(void *)ml->memos);
 					send_notice_to_user(sourceNick, callerUser, "Number of Memos: %ld",				ml->n_memos);

--- a/src/messages.c
+++ b/src/messages.c
@@ -564,7 +564,7 @@ static void m_whois(CSTR source, const int ac, char **av) {
 
 		send_cmd("311 %s %s %s %s * :%s", source, localUser->nick, localUser->username, localUser->maskedHost, localUser->realname);
 		send_cmd("312 %s %s %s :%s", source, localUser->nick, CONF_SERVICES_NAME, CONF_SERVICES_DESC);
-		send_cmd("317 %s %s %lu %lu :seconds idle, signon time", source, localUser->nick, (NOW - localUser->signon), localUser->signon);
+		send_cmd("317 %s %s %ld %ld :seconds idle, signon time", source, localUser->nick, (NOW - localUser->signon), localUser->signon);
 	}
 
 	send_cmd("318 %s %s :End of /WHOIS list.", source, av[1]);

--- a/src/nickserv.c
+++ b/src/nickserv.c
@@ -686,9 +686,9 @@ void expire_nicks() {
 
 	TRACE();
 	if (CONF_DISPLAY_UPDATES)
-		send_globops(NULL, "Completed Nick Expire (\2%d\2/\2%d\2/\2%d\2)", xcount, rcount, count);
+		send_globops(NULL, "Completed Nick Expire (\2%ld\2/\2%ld\2/\2%ld\2)", xcount, rcount, count);
 	else
-		LOG_SNOOP(s_OperServ, "Completed Nick Expire (\2%d\2/\2%d\2/\2%d\2)", xcount, rcount, count);
+		LOG_SNOOP(s_OperServ, "Completed Nick Expire (\2%ld\2/\2%ld\2/\2%ld\2)", xcount, rcount, count);
 }
 
 /*********************************************************/
@@ -762,9 +762,9 @@ void nickserv_daily_expire() {
 
 	TRACE();
 	if (CONF_DISPLAY_UPDATES)
-		send_globops(NULL, "Completed Nick Daily Expire (\2%d\2/\2%d\2)", xcount, count);
+		send_globops(NULL, "Completed Nick Daily Expire (\2%ld\2/\2%ld\2)", xcount, count);
 	else
-		LOG_SNOOP(s_OperServ, "Completed Nick Daily Expire (\2%d\2/\2%d\2)", xcount, count);
+		LOG_SNOOP(s_OperServ, "Completed Nick Daily Expire (\2%ld\2/\2%ld\2)", xcount, count);
 }
 
 
@@ -1257,7 +1257,7 @@ static void collide(NickInfo *ni, BOOL from_timeout) {
 		if (from_timeout)
 			AddFlag(ni->flags, NI_ENFORCE);
 
-		snprintf(newnick, sizeof(newnick), "Guest%d", grn);
+		snprintf(newnick, sizeof(newnick), "Guest%u", grn);
 		send_SVSNICK(ni->nick, newnick);
 	}
 }
@@ -4174,7 +4174,7 @@ static void do_forbid(CSTR source, User *callerUser, ServiceCommandData *data) {
 				}
 			}
 
-			snprintf(newnick, sizeof(newnick), "Guest%d", grn);
+			snprintf(newnick, sizeof(newnick), "Guest%u", grn);
 
 			TRACE();
 
@@ -4375,7 +4375,7 @@ static void do_freeze(CSTR source, User *callerUser, ServiceCommandData *data) {
 				}
 			}
 
-			snprintf(newnick, sizeof(newnick), "Guest%d", grn);
+			snprintf(newnick, sizeof(newnick), "Guest%u", grn);
 
 			TRACE();
 
@@ -5624,15 +5624,15 @@ static void do_nickset(CSTR source, User *callerUser, ServiceCommandData *data) 
 
 		if (data->operMatch) {
 
-			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) [D: %lu -> %lu]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, ni->time_registered, newdate);
-			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) [D: %lu -> %lu]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, ni->time_registered, newdate);
+			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) [D: %ld -> %ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, ni->time_registered, newdate);
+			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) [D: %ld -> %ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, ni->time_registered, newdate);
 
 			send_globops(s_NickServ, "\2%s\2 changed registration date for \2%s\2 to: %s (was: %s)", callerUser->nick, ni->nick, newtimebuf, timebuf);
 		}
 		else {
 
-			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) through %s [D: %lu -> %lu]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->time_registered, newdate);
-			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) through %s [D: %lu -> %lu]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->time_registered, newdate);
+			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) through %s [D: %ld -> %ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->time_registered, newdate);
+			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) through %s [D: %ld -> %ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->time_registered, newdate);
 
 			send_globops(s_NickServ, "\2%s\2 (through \2%s\2) changed registration date for \2%s\2 to: %s (was: %s)", callerUser->nick, data->operName, ni->nick, newtimebuf, timebuf);
 		}
@@ -5683,15 +5683,15 @@ static void do_nickset(CSTR source, User *callerUser, ServiceCommandData *data) 
 
 		if (data->operMatch) {
 
-			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) [S: %lu -> %lu]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, ni->last_seen, newdate);
-			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) [S: %lu -> %lu]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, ni->last_seen, newdate);
+			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) [S: %ld -> %ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, ni->last_seen, newdate);
+			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) [S: %ld -> %ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, ni->last_seen, newdate);
 
 			send_globops(s_NickServ, "\2%s\2 changed last seen for \2%s\2 to: %s (was: %s)", callerUser->nick, ni->nick, newtimebuf, timebuf);
 		}
 		else {
 
-			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) through %s [S: %lu -> %lu]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->last_seen, newdate);
-			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) through %s [S: %lu -> %lu]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->last_seen, newdate);
+			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) through %s [S: %ld -> %ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->last_seen, newdate);
+			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) through %s [S: %ld -> %ld]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->last_seen, newdate);
 
 			send_globops(s_NickServ, "\2%s\2 (through \2%s\2) changed last seen for \2%s\2 to: %s (was: %s)", callerUser->nick, data->operName, ni->nick, newtimebuf, timebuf);
 		}
@@ -5776,8 +5776,8 @@ static void do_nickset(CSTR source, User *callerUser, ServiceCommandData *data) 
 		}
 		else {
 
-			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) through %s [U: %s -> %s]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->channelcount, newcount);
-			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) through %s [U: %s -> %s]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->channelcount, newcount);
+			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) through %s [U: %d -> %d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->channelcount, newcount);
+			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) through %s [U: %d -> %d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->channelcount, newcount);
 
 			send_globops(s_NickServ, "\2%s\2 (through \2%s\2) changed channel count value for \2%s\2 to \2%d\2 (was: \2%d\2)", callerUser->nick, data->operName, ni->channelcount, newcount);
 		}

--- a/src/nickserv.c
+++ b/src/nickserv.c
@@ -5868,14 +5868,14 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: nickname \2%s\2", value);
 
-					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",				ni, sizeof(NickInfo));
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",				(void *)ni, sizeof(NickInfo));
 					send_notice_to_user(sourceNick, callerUser, "Name: %s",								ni->nick);
 					send_notice_to_user(sourceNick, callerUser, "Password: [REDACTED]");
-					send_notice_to_user(sourceNick, callerUser, "Last Mask: %p \2[\2%s\2]\2",			ni->last_usermask, str_get_valid_display_value(ni->last_usermask));
-					send_notice_to_user(sourceNick, callerUser, "Last Real Name: %p \2[\2%s\2]\2",		ni->last_realname, str_get_valid_display_value(ni->last_realname));
+					send_notice_to_user(sourceNick, callerUser, "Last Mask: %p \2[\2%s\2]\2",			(void *)ni->last_usermask, str_get_valid_display_value(ni->last_usermask));
+					send_notice_to_user(sourceNick, callerUser, "Last Real Name: %p \2[\2%s\2]\2",		(void *)ni->last_realname, str_get_valid_display_value(ni->last_realname));
 					send_notice_to_user(sourceNick, callerUser, "Registration C-time: %ld",				ni->time_registered);
 					send_notice_to_user(sourceNick, callerUser, "Last seen C-time: %ld",				ni->last_seen);
-					send_notice_to_user(sourceNick, callerUser, "Access count / list: %ld / %p",		ni->accesscount, ni->access);
+					send_notice_to_user(sourceNick, callerUser, "Access count / list: %ld / %p",		ni->accesscount, (void *)ni->access);
 					send_notice_to_user(sourceNick, callerUser, "Flags: %#lx (%s)",						(unsigned long)ni->flags, get_nick_flags(ni->flags));
 					send_notice_to_user(sourceNick, callerUser, "Last Drop Request C-time: %ld",		ni->last_drop_request);
 					send_notice_to_user(sourceNick, callerUser, "Last E-Mail Request C-time: %ld",		ni->last_email_request);
@@ -5883,17 +5883,17 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					send_notice_to_user(sourceNick, callerUser, "Channels count: %d",					ni->channelcount);
 					send_notice_to_user(sourceNick, callerUser, "News check value: %d",					ni->news);
 					send_notice_to_user(sourceNick, callerUser, "Registration E-Mail: %p \2[\2%s\2]\2",	ni->regemail, str_get_valid_display_value(ni->regemail));
-					send_notice_to_user(sourceNick, callerUser, "URL: %p \2[\2%s\2]\2",					ni->url, str_get_valid_display_value(ni->url));
-					send_notice_to_user(sourceNick, callerUser, "New E-Mail: %p \2[\2%s\2]\2",			ni->email, str_get_valid_display_value(ni->email));
-					send_notice_to_user(sourceNick, callerUser, "Memo forwarded to: %p \2[\2%s\2]\2",	ni->forward, str_get_valid_display_value(ni->forward));
-					send_notice_to_user(sourceNick, callerUser, "Hold by: %p \2[\2%s\2]\2",				ni->hold, str_get_valid_display_value(ni->hold));
-					send_notice_to_user(sourceNick, callerUser, "Marked by: %p \2[\2%s\2]\2",			ni->mark, str_get_valid_display_value(ni->mark));
-					send_notice_to_user(sourceNick, callerUser, "Frozen by: %p \2[\2%s\2]\2",			ni->freeze, str_get_valid_display_value(ni->freeze));
-					send_notice_to_user(sourceNick, callerUser, "Forbidden by: %p \2[\2%s\2]\2",		ni->forbid, str_get_valid_display_value(ni->forbid));
+					send_notice_to_user(sourceNick, callerUser, "URL: %p \2[\2%s\2]\2",					(void *)ni->url, str_get_valid_display_value(ni->url));
+					send_notice_to_user(sourceNick, callerUser, "New E-Mail: %p \2[\2%s\2]\2",			(void *)ni->email, str_get_valid_display_value(ni->email));
+					send_notice_to_user(sourceNick, callerUser, "Memo forwarded to: %p \2[\2%s\2]\2",	(void *)ni->forward, str_get_valid_display_value(ni->forward));
+					send_notice_to_user(sourceNick, callerUser, "Hold by: %p \2[\2%s\2]\2",				(void *)ni->hold, str_get_valid_display_value(ni->hold));
+					send_notice_to_user(sourceNick, callerUser, "Marked by: %p \2[\2%s\2]\2",			(void *)ni->mark, str_get_valid_display_value(ni->mark));
+					send_notice_to_user(sourceNick, callerUser, "Frozen by: %p \2[\2%s\2]\2",			(void *)ni->freeze, str_get_valid_display_value(ni->freeze));
+					send_notice_to_user(sourceNick, callerUser, "Forbidden by: %p \2[\2%s\2]\2",		(void *)ni->forbid, str_get_valid_display_value(ni->forbid));
 					send_notice_to_user(sourceNick, callerUser, "Auth code: %lu",						ni->auth);
 					send_notice_to_user(sourceNick, callerUser, "LangID: %d (%u)",						ni->langID, EXTRACT_LANG_ID(ni->langID));
 					send_notice_to_user(sourceNick, callerUser, "reserved[3]: %u %u %u",				ni->reserved[0], ni->reserved[1], ni->reserved[2]);
-					send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",		ni->next, ni->prev);
+					send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",		(void *)ni->next, (void *)ni->prev);
 
 					LOG_DEBUG_SNOOP("Command: DUMP NICKSERV NICK %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -5949,7 +5949,7 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			MemoryPoolStats pstats;
 
 			mempool_stats(nickdb_mempool, &pstats);
-			send_notice_to_user(sourceNick, callerUser, "DUMP: NickServ memory pool - Address %p, ID: %u",	nickdb_mempool, pstats.id);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: NickServ memory pool - Address %p, ID: %u",	(void *)nickdb_mempool, pstats.id);
 			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",			pstats.memory_allocated, pstats.memory_free);
 			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",				pstats.items_allocated, pstats.items_free);
 			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",			pstats.items_per_block, pstats.block_count);

--- a/src/nickserv.c
+++ b/src/nickserv.c
@@ -1430,13 +1430,13 @@ static void do_register(CSTR source, User *callerUser, ServiceCommandData *data)
 
 		if (dynConf.ns_regLimit <= ns_regCount) {
 
-			send_globops(s_NickServ, "\2%s\2 hit the maximum number of registrations allowed (\2%d\2/\2%d\2)", s_NickServ, ns_regCount, dynConf.ns_regLimit);
+			send_globops(s_NickServ, "\2%s\2 hit the maximum number of registrations allowed (\2%lu\2/\2%lu\2)", s_NickServ, ns_regCount, dynConf.ns_regLimit);
 			send_notice_lang_to_user(s_NickServ, callerUser, GetCallerLang(), CSNS_ERROR_MAX_REG_REACHED);
 			return;
 
 		}
 		else if (dynConf.ns_regLimit <= (ns_regCount + 10))
-			send_globops(s_NickServ, "\2%s\2 is about to hit the maximum number of registrations allowed (\2%d\2/\2%d\2)", s_NickServ, ns_regCount, dynConf.ns_regLimit);
+			send_globops(s_NickServ, "\2%s\2 is about to hit the maximum number of registrations allowed (\2%lu\2/\2%lu\2)", s_NickServ, ns_regCount, dynConf.ns_regLimit);
 	}
 
 	TRACE_MAIN();
@@ -5779,7 +5779,7 @@ static void do_nickset(CSTR source, User *callerUser, ServiceCommandData *data) 
 			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) through %s [U: %d -> %d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->channelcount, newcount);
 			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) through %s [U: %d -> %d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->channelcount, newcount);
 
-			send_globops(s_NickServ, "\2%s\2 (through \2%s\2) changed channel count value for \2%s\2 to \2%d\2 (was: \2%d\2)", callerUser->nick, data->operName, ni->channelcount, newcount);
+			send_globops(s_NickServ, "\2%s\2 (through \2%s\2) changed channel count value for \2%s\2 to \2%d\2 (was: \2%d\2)", callerUser->nick, data->operName, ni->nick, ni->channelcount, newcount);
 		}
 
 		ni->channelcount = newcount;

--- a/src/nickserv.c
+++ b/src/nickserv.c
@@ -5779,7 +5779,7 @@ static void do_nickset(CSTR source, User *callerUser, ServiceCommandData *data) 
 			LOG_SNOOP(s_OperServ, "NS N %s -- by %s (%s@%s) through %s [U: %d -> %d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->channelcount, newcount);
 			log_services(LOG_SERVICES_NICKSERV_GENERAL, "N %s -- by %s (%s@%s) through %s [U: %d -> %d]", ni->nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, ni->channelcount, newcount);
 
-			send_globops(s_NickServ, "\2%s\2 (through \2%s\2) changed channel count value for \2%s\2 to \2%d\2 (was: \2%d\2)", callerUser->nick, data->operName, ni->nick, ni->channelcount, newcount);
+			send_globops(s_NickServ, "\2%s\2 (through \2%s\2) changed channel count value for \2%s\2 to \2%d\2 (was: \2%d\2)", callerUser->nick, data->operName, ni->nick, newcount, ni->channelcount);
 		}
 
 		ni->channelcount = newcount;

--- a/src/nickserv.c
+++ b/src/nickserv.c
@@ -5375,17 +5375,17 @@ static void do_listreg(CSTR source, User *callerUser, ServiceCommandData *data) 
 
 					case LR_OUT_STANDARD:
 						if (FlagSet(ni->flags, NI_FORBIDDEN))
-							send_notice_to_user(s_NickServ, callerUser, "%d) \2%s\2 [Forbidden by %s]", line, ni->nick, ni->forbid);
+							send_notice_to_user(s_NickServ, callerUser, "%lu) \2%s\2 [Forbidden by %s]", line, ni->nick, ni->forbid);
 						else
-							send_notice_to_user(s_NickServ, callerUser, "%d) \2%s\2 [%s]", line, ni->nick, ni->last_usermask);
+							send_notice_to_user(s_NickServ, callerUser, "%lu) \2%s\2 [%s]", line, ni->nick, ni->last_usermask);
 						break;
 					
 					case LR_OUT_REALNAME:
-						send_notice_to_user(s_NickServ, callerUser, "%d) \2%s\2 [%s] [Real Name: %s]", line, ni->nick, ni->last_usermask, ni->last_realname);
+						send_notice_to_user(s_NickServ, callerUser, "%lu) \2%s\2 [%s] [Real Name: %s]", line, ni->nick, ni->last_usermask, ni->last_realname);
 						break;
 
 					case LR_OUT_EMAIL:
-						send_notice_to_user(s_NickServ, callerUser, "%d) \2%s\2 [%s] [E-Mail Address: %s]", line, ni->nick, ni->last_usermask, ni->email);
+						send_notice_to_user(s_NickServ, callerUser, "%lu) \2%s\2 [%s] [E-Mail Address: %s]", line, ni->nick, ni->last_usermask, ni->email);
 						break;
 				}
 
@@ -5868,32 +5868,32 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: nickname \2%s\2", value);
 
-					send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",						(unsigned long)ni, sizeof(NickInfo));
-					send_notice_to_user(sourceNick, callerUser, "Name: %s",											ni->nick);
-					send_notice_to_user(sourceNick, callerUser, "Password: %s",										ni->pass);
-					send_notice_to_user(sourceNick, callerUser, "Last Mask: 0x%08X \2[\2%s\2]\2",					(unsigned long)ni->last_usermask, str_get_valid_display_value(ni->last_usermask));
-					send_notice_to_user(sourceNick, callerUser, "Last Real Name: 0x%08X \2[\2%s\2]\2",				(unsigned long)ni->last_realname, str_get_valid_display_value(ni->last_realname));
-					send_notice_to_user(sourceNick, callerUser, "Registration C-time: %d",							ni->time_registered);
-					send_notice_to_user(sourceNick, callerUser, "Last seen C-time: %d",								ni->last_seen);
-					send_notice_to_user(sourceNick, callerUser, "Access count / list: %d / 0x%08X",					ni->accesscount, (unsigned long)ni->access);
-					send_notice_to_user(sourceNick, callerUser, "Flags: 0x%08X (%s)",								(unsigned long)ni->flags, get_nick_flags(ni->flags));
-					send_notice_to_user(sourceNick, callerUser, "Last Drop Request C-time: %d",						ni->last_drop_request);
-					send_notice_to_user(sourceNick, callerUser, "Last E-Mail Request C-time: %d",					ni->last_email_request);
-					send_notice_to_user(sourceNick, callerUser, "Max memos: %d",									ni->memomax);
-					send_notice_to_user(sourceNick, callerUser, "Channels count: %d",								ni->channelcount);
-					send_notice_to_user(sourceNick, callerUser, "News check value: %d",								ni->news);
-					send_notice_to_user(sourceNick, callerUser, "Registration E-Mail: 0x%08X \2[\2%s\2]\2",			(unsigned long)ni->regemail, str_get_valid_display_value(ni->regemail));
-					send_notice_to_user(sourceNick, callerUser, "URL: 0x%08X \2[\2%s\2]\2",							(unsigned long)ni->url, str_get_valid_display_value(ni->url));
-					send_notice_to_user(sourceNick, callerUser, "New E-Mail: 0x%08X \2[\2%s\2]\2",					(unsigned long)ni->email, str_get_valid_display_value(ni->email));
-					send_notice_to_user(sourceNick, callerUser, "Memo forwarded to: 0x%08X \2[\2%s\2]\2",			(unsigned long)ni->forward, str_get_valid_display_value(ni->forward));
-					send_notice_to_user(sourceNick, callerUser, "Hold by: 0x%08X \2[\2%s\2]\2",						(unsigned long)ni->hold, str_get_valid_display_value(ni->hold));
-					send_notice_to_user(sourceNick, callerUser, "Marked by: 0x%08X \2[\2%s\2]\2",					(unsigned long)ni->mark, str_get_valid_display_value(ni->mark));
-					send_notice_to_user(sourceNick, callerUser, "Frozen by: 0x%08X \2[\2%s\2]\2",					(unsigned long)ni->freeze, str_get_valid_display_value(ni->freeze));
-					send_notice_to_user(sourceNick, callerUser, "Forbidden by: 0x%08X \2[\2%s\2]\2",				(unsigned long)ni->forbid, str_get_valid_display_value(ni->forbid));
-					send_notice_to_user(sourceNick, callerUser, "Auth code: %d",									ni->auth);
-					send_notice_to_user(sourceNick, callerUser, "LangID: %d (%d)",									ni->langID, EXTRACT_LANG_ID(ni->langID));
-					send_notice_to_user(sourceNick, callerUser, "reserved[3]: %d %d %d",							ni->reserved[0], ni->reserved[1], ni->reserved[2]);
-					send_notice_to_user(sourceNick, callerUser, "Next / previous record: 0x%08X / 0x%08X",			(unsigned long)ni->next, (unsigned long)ni->prev);
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",				ni, sizeof(NickInfo));
+					send_notice_to_user(sourceNick, callerUser, "Name: %s",								ni->nick);
+					send_notice_to_user(sourceNick, callerUser, "Password: [REDACTED]");
+					send_notice_to_user(sourceNick, callerUser, "Last Mask: %p \2[\2%s\2]\2",			ni->last_usermask, str_get_valid_display_value(ni->last_usermask));
+					send_notice_to_user(sourceNick, callerUser, "Last Real Name: %p \2[\2%s\2]\2",		ni->last_realname, str_get_valid_display_value(ni->last_realname));
+					send_notice_to_user(sourceNick, callerUser, "Registration C-time: %ld",				ni->time_registered);
+					send_notice_to_user(sourceNick, callerUser, "Last seen C-time: %ld",				ni->last_seen);
+					send_notice_to_user(sourceNick, callerUser, "Access count / list: %ld / %p",		ni->accesscount, ni->access);
+					send_notice_to_user(sourceNick, callerUser, "Flags: %#lx (%s)",						(unsigned long)ni->flags, get_nick_flags(ni->flags));
+					send_notice_to_user(sourceNick, callerUser, "Last Drop Request C-time: %ld",		ni->last_drop_request);
+					send_notice_to_user(sourceNick, callerUser, "Last E-Mail Request C-time: %ld",		ni->last_email_request);
+					send_notice_to_user(sourceNick, callerUser, "Max memos: %d",						ni->memomax);
+					send_notice_to_user(sourceNick, callerUser, "Channels count: %d",					ni->channelcount);
+					send_notice_to_user(sourceNick, callerUser, "News check value: %d",					ni->news);
+					send_notice_to_user(sourceNick, callerUser, "Registration E-Mail: %p \2[\2%s\2]\2",	ni->regemail, str_get_valid_display_value(ni->regemail));
+					send_notice_to_user(sourceNick, callerUser, "URL: %p \2[\2%s\2]\2",					ni->url, str_get_valid_display_value(ni->url));
+					send_notice_to_user(sourceNick, callerUser, "New E-Mail: %p \2[\2%s\2]\2",			ni->email, str_get_valid_display_value(ni->email));
+					send_notice_to_user(sourceNick, callerUser, "Memo forwarded to: %p \2[\2%s\2]\2",	ni->forward, str_get_valid_display_value(ni->forward));
+					send_notice_to_user(sourceNick, callerUser, "Hold by: %p \2[\2%s\2]\2",				ni->hold, str_get_valid_display_value(ni->hold));
+					send_notice_to_user(sourceNick, callerUser, "Marked by: %p \2[\2%s\2]\2",			ni->mark, str_get_valid_display_value(ni->mark));
+					send_notice_to_user(sourceNick, callerUser, "Frozen by: %p \2[\2%s\2]\2",			ni->freeze, str_get_valid_display_value(ni->freeze));
+					send_notice_to_user(sourceNick, callerUser, "Forbidden by: %p \2[\2%s\2]\2",		ni->forbid, str_get_valid_display_value(ni->forbid));
+					send_notice_to_user(sourceNick, callerUser, "Auth code: %lu",						ni->auth);
+					send_notice_to_user(sourceNick, callerUser, "LangID: %d (%u)",						ni->langID, EXTRACT_LANG_ID(ni->langID));
+					send_notice_to_user(sourceNick, callerUser, "reserved[3]: %u %u %u",				ni->reserved[0], ni->reserved[1], ni->reserved[2]);
+					send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",		ni->next, ni->prev);
 
 					LOG_DEBUG_SNOOP("Command: DUMP NICKSERV NICK %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -5919,7 +5919,7 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 						send_notice_to_user(sourceNick, callerUser, "DUMP: Access List for nickname \2%s\2", value);
 
 					for (anAccess = ni->access, i = 0; i < ni->accesscount; ++anAccess, ++i)
-						send_notice_to_user(sourceNick, callerUser, "%d) Mask: 0x%08X \2[\2%s\2]\2", i+1, (unsigned long)*anAccess, *anAccess);
+						send_notice_to_user(sourceNick, callerUser, "%ld) Mask: %p \2[\2%s\2]\2", i+1, *anAccess, *anAccess);
 
 					LOG_DEBUG_SNOOP("Command: DUMP NICKSERV ACCESS %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -5928,14 +5928,14 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 			unsigned int	idx, n;
 
-			send_notice_to_user(sourceNick, callerUser, "DUMP: Guest Used List (\2 0x%08X \2)", nickserv_used_guest_list);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: Guest Used List (\2 %p \2)", nickserv_used_guest_list);
 
 			if (IS_NOT_NULL(nickserv_used_guest_list)) {
 
 				for (idx = 0, n = 0; idx < 99999 - 10000 + 1; ++idx) {
 
 					if (nickserv_used_guest_list[idx] == 1)
-						send_notice_to_user(sourceNick, callerUser, "%d) \2%d\2", n++, idx + 10000);
+						send_notice_to_user(sourceNick, callerUser, "%u) \2%u\2", n++, idx + 10000);
 				}
 			}
 
@@ -5949,10 +5949,10 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			MemoryPoolStats pstats;
 
 			mempool_stats(nickdb_mempool, &pstats);
-			send_notice_to_user(sourceNick, callerUser, "DUMP: NickServ memory pool - Address 0x%08X, ID: %d",	(unsigned long)nickdb_mempool, pstats.id);
-			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %d B / %d B",				pstats.memory_allocated, pstats.memory_free);
-			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %d / %d",					pstats.items_allocated, pstats.items_free);
-			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %d / %d",			pstats.items_per_block, pstats.block_count);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: NickServ memory pool - Address %p, ID: %u",	nickdb_mempool, pstats.id);
+			send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",			pstats.memory_allocated, pstats.memory_free);
+			send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",				pstats.items_allocated, pstats.items_free);
+			send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",			pstats.items_per_block, pstats.block_count);
 			//send_notice_to_user(sourceNick, callerUser, "Avarage use: %.2f%%",								pstats.block_avg_usage);
 
 		#endif
@@ -6039,7 +6039,7 @@ unsigned long nickserv_mem_report(CSTR sourceNick, const User *callerUser) {
 	}
 
 	total_mem = mem;
-	send_notice_to_user(sourceNick, callerUser, "Record: \2%d\2 [%d] -> \2%d\2 KB (\2%d\2 B)", count, ns_regCount, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Record: \2%lu\2 [%lu] -> \2%lu\2 KB (\2%lu\2 B)", count, ns_regCount, mem / 1024, mem);
 
 	return total_mem;
 }

--- a/src/nickserv.c
+++ b/src/nickserv.c
@@ -1568,9 +1568,9 @@ static void do_register(CSTR source, User *callerUser, ServiceCommandData *data)
 
 				fprintf(mailfile, lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_SUBJECT), callerUser->ni->nick);
 				fprintf(mailfile, lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_1), CONF_NETWORK_NAME, callerUser->ni->auth, CONF_NETWORK_NAME, callerUser->ni->nick, s_NickServ, callerUser->ni->auth);
-				fprintf(mailfile, lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_2));
-				fprintf(mailfile, lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_3));
-				fprintf(mailfile, lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_4));
+				fprintf(mailfile, "%s", lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_2)); /* FIXME: prevent false positive for format-security, should go away if/when we move lang stuff to gettext */
+				fprintf(mailfile, "%s", lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_3)); /* FIXME: prevent false positive for format-security, should go away if/when we move lang stuff to gettext */
+				fprintf(mailfile, "%s", lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_4)); /* FIXME: prevent false positive for format-security, should go away if/when we move lang stuff to gettext */
 				fprintf(mailfile, lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_5), CONF_NETWORK_NAME, CONF_NETWORK_NAME);
 				fprintf(mailfile, lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_6), CONF_NETWORK_NAME, CONF_NETWORK_NAME);
 				fprintf(mailfile, lang_msg(GetCallerLang(), NS_REGISTER_EMAIL_TEXT_7), CONF_NETWORK_NAME);

--- a/src/nickserv.c
+++ b/src/nickserv.c
@@ -5882,7 +5882,7 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					send_notice_to_user(sourceNick, callerUser, "Max memos: %d",						ni->memomax);
 					send_notice_to_user(sourceNick, callerUser, "Channels count: %d",					ni->channelcount);
 					send_notice_to_user(sourceNick, callerUser, "News check value: %d",					ni->news);
-					send_notice_to_user(sourceNick, callerUser, "Registration E-Mail: %p \2[\2%s\2]\2",	ni->regemail, str_get_valid_display_value(ni->regemail));
+					send_notice_to_user(sourceNick, callerUser, "Registration E-Mail: %p \2[\2%s\2]\2",	(void *)ni->regemail, str_get_valid_display_value(ni->regemail));
 					send_notice_to_user(sourceNick, callerUser, "URL: %p \2[\2%s\2]\2",					(void *)ni->url, str_get_valid_display_value(ni->url));
 					send_notice_to_user(sourceNick, callerUser, "New E-Mail: %p \2[\2%s\2]\2",			(void *)ni->email, str_get_valid_display_value(ni->email));
 					send_notice_to_user(sourceNick, callerUser, "Memo forwarded to: %p \2[\2%s\2]\2",	(void *)ni->forward, str_get_valid_display_value(ni->forward));
@@ -5919,7 +5919,7 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 						send_notice_to_user(sourceNick, callerUser, "DUMP: Access List for nickname \2%s\2", value);
 
 					for (anAccess = ni->access, i = 0; i < ni->accesscount; ++anAccess, ++i)
-						send_notice_to_user(sourceNick, callerUser, "%ld) Mask: %p \2[\2%s\2]\2", i+1, *anAccess, *anAccess);
+						send_notice_to_user(sourceNick, callerUser, "%ld) Mask: %p \2[\2%s\2]\2", i+1, (void *)*anAccess, *anAccess);
 
 					LOG_DEBUG_SNOOP("Command: DUMP NICKSERV ACCESS %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -5928,7 +5928,7 @@ void nickserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 			unsigned int	idx, n;
 
-			send_notice_to_user(sourceNick, callerUser, "DUMP: Guest Used List (\2 %p \2)", nickserv_used_guest_list);
+			send_notice_to_user(sourceNick, callerUser, "DUMP: Guest Used List (\2 %p \2)", (void *)nickserv_used_guest_list);
 
 			if (IS_NOT_NULL(nickserv_used_guest_list)) {
 

--- a/src/oper.c
+++ b/src/oper.c
@@ -640,7 +640,7 @@ static void send_oper_list(const char *sourceNick, const User *target, int acces
 	if (last)
 		send_notice_to_user(sourceNick, target, "*** \2End of List\2 ***");
 	else if (need_header == FALSE)
-		send_notice_to_user(sourceNick, target, s_SPACE);
+		send_notice_to_user(sourceNick, target, " ");
 }
 
 /*********************************************************/
@@ -1708,14 +1708,14 @@ void oper_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: Oper entry for \2%s\2", nick);
 
-					send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",						(unsigned long)oper, sizeof(Oper));
-					send_notice_to_user(sourceNick, callerUser, "Nick: 0x%08X \2[\2%s\2]\2",						(unsigned long)oper->nick, str_get_valid_display_value(oper->nick));
-					send_notice_to_user(sourceNick, callerUser, "Creator: 0x%08X \2[\2%s\2]\2",						(unsigned long)oper->creator.name, str_get_valid_display_value(oper->creator.name));
-					send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",							oper->creator.time);
-					send_notice_to_user(sourceNick, callerUser, "Last Update C-time: %ld",							oper->lastUpdate);
-					send_notice_to_user(sourceNick, callerUser, "Level: %d \2[\2%s\2]\2",							oper->level, get_access_name(oper->level, FALSE));
-					send_notice_to_user(sourceNick, callerUser, "Flags: %ld",										oper->flags);
-					send_notice_to_user(sourceNick, callerUser, "Next/Previous record: 0x%08X / 0x%08X",			(unsigned long)oper->next, (unsigned long)oper->prev);
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			oper, sizeof(Oper));
+					send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",			oper->nick, str_get_valid_display_value(oper->nick));
+					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			oper->creator.name, str_get_valid_display_value(oper->creator.name));
+					send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",			oper->creator.time);
+					send_notice_to_user(sourceNick, callerUser, "Last Update C-time: %ld",			oper->lastUpdate);
+					send_notice_to_user(sourceNick, callerUser, "Level: %d \2[\2%s\2]\2",			oper->level, get_access_name(oper->level, FALSE));
+					send_notice_to_user(sourceNick, callerUser, "Flags: %#lx",						oper->flags);
+					send_notice_to_user(sourceNick, callerUser, "Next/Previous record: %p / %p",	oper->next, oper->prev);
 
 					LOG_DEBUG_SNOOP("Command: DUMP OPER NICK %s -- by %s (%s@%s)", nick, callerUser->nick, callerUser->username, callerUser->host);
 				}
@@ -1733,7 +1733,7 @@ void oper_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			for (i = FIRST_VALID_NICK_CHAR; i <= LAST_VALID_NICK_CHAR; ++i) {
 
 				for (oper = opers[i]; IS_NOT_NULL(oper); oper = oper->next)
-					send_notice_to_user(sourceNick, callerUser, "%d) \2%s\2 [Added by %s]", ++count, oper->nick, oper->creator);
+					send_notice_to_user(sourceNick, callerUser, "%d) \2%s\2 [Added by %s]", ++count, oper->nick, str_get_valid_display_value(oper->creator.name));
 			}
 					
 			LOG_DEBUG_SNOOP("Command: DUMP OPER LIST -- by %s (%s@%s)", callerUser->nick, callerUser->username, callerUser->host);
@@ -1778,7 +1778,7 @@ unsigned long oper_mem_report(CSTR sourceNick, const User *callerUser) {
 	}
 
 	total_mem += mem;
-	send_notice_to_user(sourceNick, callerUser, "Records: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Records: \2%d\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 
 	return total_mem;
 }

--- a/src/oper.c
+++ b/src/oper.c
@@ -1708,14 +1708,14 @@ void oper_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 					send_notice_to_user(sourceNick, callerUser, "DUMP: Oper entry for \2%s\2", nick);
 
-					send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			oper, sizeof(Oper));
-					send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",			oper->nick, str_get_valid_display_value(oper->nick));
-					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			oper->creator.name, str_get_valid_display_value(oper->creator.name));
+					send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",			(void *)oper, sizeof(Oper));
+					send_notice_to_user(sourceNick, callerUser, "Nick: %p \2[\2%s\2]\2",			(void *)oper->nick, str_get_valid_display_value(oper->nick));
+					send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",			(void *)oper->creator.name, str_get_valid_display_value(oper->creator.name));
 					send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",			oper->creator.time);
 					send_notice_to_user(sourceNick, callerUser, "Last Update C-time: %ld",			oper->lastUpdate);
 					send_notice_to_user(sourceNick, callerUser, "Level: %d \2[\2%s\2]\2",			oper->level, get_access_name(oper->level, FALSE));
 					send_notice_to_user(sourceNick, callerUser, "Flags: %#lx",						oper->flags);
-					send_notice_to_user(sourceNick, callerUser, "Next/Previous record: %p / %p",	oper->next, oper->prev);
+					send_notice_to_user(sourceNick, callerUser, "Next/Previous record: %p / %p",	(void *)oper->next, (void *)oper->prev);
 
 					LOG_DEBUG_SNOOP("Command: DUMP OPER NICK %s -- by %s (%s@%s)", nick, callerUser->nick, callerUser->username, callerUser->host);
 				}

--- a/src/operserv.c
+++ b/src/operserv.c
@@ -792,8 +792,8 @@ static void do_settings(CSTR source, User *callerUser, ServiceCommandData *data)
 	else
 		LOG_SNOOP(s_OperServ, "OS Se -- by %s (%s@%s) through %s", callerUser->nick, callerUser->username, callerUser->host, data->operName);
 
-	send_notice_to_user(s_OperServ, callerUser, "*** \2Services Settings List\2 ***", s_OperServ);
-	send_notice_to_user(s_OperServ, callerUser, s_SPACE);
+	send_notice_to_user(s_OperServ, callerUser, "*** \2Services Settings List\2 ***");
+	send_notice_to_user(s_OperServ, callerUser, " ");
 
 	send_notice_to_user(s_OperServ, callerUser, "CAPABs enabled: %s", (CAPAB[5] == '\0') ?  "None" : (CAPAB + 6));
 
@@ -802,25 +802,25 @@ static void do_settings(CSTR source, User *callerUser, ServiceCommandData *data)
 	send_notice_to_user(s_OperServ, callerUser, "DataBase Update Frequency: %s", convert_time(buffer, sizeof(buffer), CONF_DATABASE_UPDATE_FREQUENCY, LANG_DEFAULT));
 
 	TRACE_MAIN();
-	send_notice_to_user(s_OperServ, callerUser, "Clones: Trigger: \2%d\2 - Wait Warnings: \2%d\2 - Max Clones: \2%d\2 - Timed: \2%ds\2 - ScanV6: \2%d\2",
+	send_notice_to_user(s_OperServ, callerUser, "Clones: Trigger: \2%d\2 - Wait Warnings: \2%ld\2 - Max Clones: \2%d\2 - Timed: \2%lds\2 - ScanV6: \2%d\2",
 		CONF_CLONE_MIN_USERS, CONF_CLONE_WARNING_DELAY, CONF_AKILL_CLONES, CONF_DEFAULT_CLONEKILL_EXPIRY, CONF_CLONE_SCAN_V6);
 
-	send_notice_to_user(s_OperServ, callerUser, "Default Memo Limit: \2%d\2 - Max Memo Length:\2 450\2 - Memo Send Delay: \2%d\2",
+	send_notice_to_user(s_OperServ, callerUser, "Default Memo Limit: \2%d\2 - Max Memo Length:\2 450\2 - Memo Send Delay: \2%ld\2",
 		CONF_DEF_MAX_MEMOS, CONF_MEMO_SEND_DELAY);
 
 	send_notice_to_user(s_OperServ, callerUser, "Maximums: User Chan Access: \2%d\2 - Access List Entries: \2%d\2 - Chan Access Nicks: \2%d\2 - Chan AutoKicks: \2%d\2",
 		CONF_USER_CHAN_ACCESS_MAX, CONF_USER_ACCESS_MAX, CONF_CHAN_ACCESS_MAX, CONF_AKICK_MAX);
 
-	send_notice_to_user(s_OperServ, callerUser, "Invalid Password Max Attempts: \2%d\2 - Invalid Password Reset Time: \2%d\2 - Return E-Mail: \2%s\2",
+	send_notice_to_user(s_OperServ, callerUser, "Invalid Password Max Attempts: \2%d\2 - Invalid Password Reset Time: \2%ld\2 - Return E-Mail: \2%s\2",
 		CONF_INVALID_PASSWORD_MAX_ATTEMPTS, CONF_INVALID_PASSWORD_RESET, CONF_RETURN_EMAIL);
 
-	send_notice_to_user(s_OperServ, callerUser, "Flood Levels: \2%d\2/\2%d\2/\2%d\2 [MAXMSG:MSGRESET:LEVELRESET]",
+	send_notice_to_user(s_OperServ, callerUser, "Flood Levels: \2%d\2/\2%ld\2/\2%ld\2 [MAXMSG:MSGRESET:LEVELRESET]",
 		CONF_FLOOD_MAX_MESSAGES, CONF_FLOOD_MESSAGE_RESET, CONF_FLOOD_LEVEL_RESET);
 
 	send_notice_to_user(s_OperServ, callerUser, "Snoop Chan: \2%s\2 - Debug Chan: \2%s\2 - AutoKill Percent: \2%.0f\2 - Default Chan Modelock: \2%s\2",
 		CONF_SNOOP_CHAN, CONF_DEBUG_CHAN, CONF_AKILL_PERCENT, get_channel_mode(CONF_DEF_MLOCKON, 0));
 
-	send_notice_to_user(s_OperServ, callerUser, "Nick Release Timeout: \2%ds\2 - ChanServ/NickServ Register Delay: \2%ds\2 - Chan Inhabit: \2%ds\2",
+	send_notice_to_user(s_OperServ, callerUser, "Nick Release Timeout: \2%lds\2 - ChanServ/NickServ Register Delay: \2%lds\2 - Chan Inhabit: \2%lds\2",
 		CONF_RELEASE_TIMEOUT, CONF_REGISTER_DELAY, CONF_CHANNEL_INHABIT);
 
 	send_notice_to_user(s_OperServ, callerUser, "Expiry Times: Nicks: \2%d\2 - Chans: \2%d\2 - Memos: \2%d\2 - Stats: \2%d\2 - Seens: \2%d\2",
@@ -874,11 +874,11 @@ static void do_stats(CSTR source, User *callerUser, ServiceCommandData *data) {
 		LOG_SNOOP(s_OperServ, "OS St -- by %s (%s@%s) through %s", callerUser->nick, callerUser->username, callerUser->host, data->operName);
 
 	send_notice_to_user(s_OperServ, callerUser, "*** \2Services Stats\2 ***");
-	send_notice_to_user(s_OperServ, callerUser, "Current users: \2%d\2 (\2%d\2 ops)",
+	send_notice_to_user(s_OperServ, callerUser, "Current users: \2%u\2 (\2%u\2 ops)",
 		user_online_user_count, user_online_operator_count);
 
 	TRACE_MAIN();
-	send_notice_to_user(s_OperServ, callerUser, "Nicks: \2%d\2/\2%d\2 - Chans: \2%d\2/\2%d\2",
+	send_notice_to_user(s_OperServ, callerUser, "Nicks: \2%lu\2/\2%lu\2 - Chans: \2%lu\2/\2%lu\2",
 		ns_regCount, dynConf.ns_regLimit, cs_regCount, dynConf.cs_regLimit);
 
 	send_notice_to_user(s_OperServ, callerUser, "G:Lines: \2%d\2 - Q:Lines: \2%d\2 - Taglines: \2%d\2",
@@ -1796,12 +1796,12 @@ void operserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 		for (idx = 0; idx < CLONE_DETECT_SIZE; ++idx) {
 
-			send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",		idx + 1, (unsigned long)idx, sizeof(CloneWarning));
-			send_notice_to_user(sourceNick, callerUser, "Host: 0x%08X \2[\2%s\2]\2",			(unsigned long)warnings[idx].host, str_get_valid_display_value(warnings[idx].host));
-			send_notice_to_user(sourceNick, callerUser, "IP: %lu \2[\2%s\2]\2",					warnings[idx].ip, get_ip(warnings[idx].ip));
-			send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %d",					warnings[idx].timeAdded);
-			send_notice_to_user(sourceNick, callerUser, "Clone count: %d",						warnings[idx].cloneCount);
-			send_notice_to_user(sourceNick, callerUser, "Flags: %d",							warnings[idx].flags);
+			send_notice_to_user(sourceNick, callerUser, "%lu) Address %p, size %lu B",	idx + 1, &warnings[idx], sizeof(CloneWarning));
+			send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		warnings[idx].host, str_get_valid_display_value(warnings[idx].host));
+			send_notice_to_user(sourceNick, callerUser, "IP: %lu \2[\2%s\2]\2",			warnings[idx].ip, get_ip(warnings[idx].ip));
+			send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			warnings[idx].timeAdded);
+			send_notice_to_user(sourceNick, callerUser, "Clone count: %d",				warnings[idx].cloneCount);
+			send_notice_to_user(sourceNick, callerUser, "Flags: %d",					warnings[idx].flags);
 		}
 
 		LOG_DEBUG_SNOOP("Command: DUMP WARNINGS -- by %s (%s@%s)", callerUser->nick, callerUser->username, callerUser->host);
@@ -1838,6 +1838,6 @@ unsigned long int operserv_mem_report(CSTR sourceNick, const User *callerUser) {
 			mem += str_len(warnings[warningIdx].host) + 1;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Clone warnings list: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", CLONE_DETECT_SIZE, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Clone warnings list: \2%d\2 -> \2%lu\2 KB (\2%lu\2 B)", CLONE_DETECT_SIZE, mem / 1024, mem);
 	return mem;
 }

--- a/src/operserv.c
+++ b/src/operserv.c
@@ -1796,8 +1796,8 @@ void operserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 		for (idx = 0; idx < CLONE_DETECT_SIZE; ++idx) {
 
-			send_notice_to_user(sourceNick, callerUser, "%lu) Address %p, size %lu B",	idx + 1, &warnings[idx], sizeof(CloneWarning));
-			send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		warnings[idx].host, str_get_valid_display_value(warnings[idx].host));
+			send_notice_to_user(sourceNick, callerUser, "%lu) Address %p, size %zu B",	idx + 1, (void *)&warnings[idx], sizeof(CloneWarning));
+			send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		(void *)warnings[idx].host, str_get_valid_display_value(warnings[idx].host));
 			send_notice_to_user(sourceNick, callerUser, "IP: %lu \2[\2%s\2]\2",			warnings[idx].ip, get_ip(warnings[idx].ip));
 			send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			warnings[idx].timeAdded);
 			send_notice_to_user(sourceNick, callerUser, "Clone count: %d",				warnings[idx].cloneCount);

--- a/src/operserv.c
+++ b/src/operserv.c
@@ -1242,12 +1242,12 @@ static void do_kick_ban(CSTR source, User *callerUser, ServiceCommandData *data)
 			if (data->operMatch) {
 
 				LOG_SNOOP(s_OperServ, "OS B %s %s -- by %s (%s@%s) [%s]", chan->name, nick, callerUser->nick, callerUser->username, callerUser->host, reason);
-				log_services(LOG_SERVICES_OPERSERV, "B %s -- by %s (%s@%s) [%s]", chan->name, nick, callerUser->nick, callerUser->username, callerUser->host, reason);
+				log_services(LOG_SERVICES_OPERSERV, "B %s %s -- by %s (%s@%s) [%s]", chan->name, nick, callerUser->nick, callerUser->username, callerUser->host, reason);
 			}
 			else {
 
 				LOG_SNOOP(s_OperServ, "OS B %s %s -- by %s (%s@%s) through %s [%s]", chan->name, nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, reason);
-				log_services(LOG_SERVICES_OPERSERV, "B %s -- by %s (%s@%s) through %s [%s]", chan->name, nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, reason);
+				log_services(LOG_SERVICES_OPERSERV, "B %s %s -- by %s (%s@%s) through %s [%s]", chan->name, nick, callerUser->nick, callerUser->username, callerUser->host, data->operName, reason);
 			}
 
 			TRACE_MAIN();

--- a/src/operserv.c
+++ b/src/operserv.c
@@ -1237,7 +1237,7 @@ static void do_kick_ban(CSTR source, User *callerUser, ServiceCommandData *data)
 
 			/* If this ban is not already present and the banlist is not full, send it. */
 			if (!chan_has_ban(chan, mask, NULL) && chan_add_ban(chan, mask))
-				send_cmd(":%s MODE %s +b %s %lu", s_OperServ, chan_name, mask, NOW);
+				send_cmd(":%s MODE %s +b %s %ld", s_OperServ, chan_name, mask, NOW);
 
 			if (data->operMatch) {
 

--- a/src/regions.c
+++ b/src/regions.c
@@ -312,7 +312,7 @@ BOOL region_list_add(Region *region) {
 		}
 		else
 			log_error(FACILITY_REGION_LIST_ADD, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_PROPAGATED,
-				"region_list_add() - Invalid region-type flag (%d)", region->flags & 0x03);
+				"region_list_add() - Invalid region-type flag (%lu)", region->flags & 0x03);
 			// fall and fail ...
 	}
 
@@ -368,7 +368,7 @@ void region_list_remove(Region *region) {
 		}
 		else
 			log_error(FACILITY_REGION_LIST_REMOVE, __LINE__, LOG_TYPE_ERROR_SANITY, LOG_SEVERITY_ERROR_PROPAGATED,
-				"region_list_remove() - Invalid region-type flag (%d)", region->flags & 0x03);
+				"region_list_remove() - Invalid region-type flag (%lu)", region->flags & 0x03);
 			// fall and fail ...
 	}
 }

--- a/src/regions.c
+++ b/src/regions.c
@@ -932,9 +932,9 @@ void handle_regions(const char *source, User *callerUser, ServiceCommandData *da
 			if (IS_NOT_NULL(region) && (error.value.cidr_error == cidrSuccess)) {
 
 				if (data->operMatch)
-					send_globops(data->agent->nick, "\2%s\2 removed CIDR for \2%s\2 from region \2%d\2", source, region->host_mask, region->id);
+					send_globops(data->agent->nick, "\2%s\2 removed CIDR for \2%s\2 from region \2%u\2", source, region->host_mask, region->id);
 				else
-					send_globops(data->agent->nick, "\2%s\2 (through \2%s\2) removed CIDR for \2%s\2 from region \2%d\2", source, data->operName, region->host_mask, region->id);
+					send_globops(data->agent->nick, "\2%s\2 (through \2%s\2) removed CIDR for \2%s\2 from region \2%u\2", source, data->operName, region->host_mask, region->id);
 
 				region_list_remove(region);
 				region_delete(region);
@@ -960,9 +960,9 @@ void handle_regions(const char *source, User *callerUser, ServiceCommandData *da
 			if (IS_NOT_NULL(region) && (error.value.host_error == RESULT_SUCCESS)) {
 
 				if (data->operMatch)
-					send_globops(data->agent->nick, "\2%s\2 removed host \2%s\2 from region \2%d\2", source, region->host_mask, region->id);
+					send_globops(data->agent->nick, "\2%s\2 removed host \2%s\2 from region \2%u\2", source, region->host_mask, region->id);
 				else
-					send_globops(data->agent->nick, "\2%s\2 (through \2%s\2) removed host \2%s\2 from region \2%d\2", source, data->operName, region->host_mask, region->id);
+					send_globops(data->agent->nick, "\2%s\2 (through \2%s\2) removed host \2%s\2 from region \2%u\2", source, data->operName, region->host_mask, region->id);
 
 				region_list_remove(region);
 				region_delete(region);

--- a/src/regions.c
+++ b/src/regions.c
@@ -1167,7 +1167,7 @@ void handle_regions(const char *source, User *callerUser, ServiceCommandData *da
 		send_notice_to_user(data->agent->nick, callerUser, "Supported regions:");
 
 		for (region_id = REGION_FIRST; region_id <= REGION_LAST; ++region_id)
-			send_notice_to_user(data->agent->nick, callerUser, "%d) \2%s\2 [%s]", region_id, regions_info[region_id].long_name, regions_info[region_id].short_name);
+			send_notice_to_user(data->agent->nick, callerUser, "%u) \2%s\2 [%s]", region_id, regions_info[region_id].long_name, regions_info[region_id].short_name);
 
 		send_notice_to_user(data->agent->nick, callerUser, "*** \2End of List\2 ***");
 	}

--- a/src/reserved.c
+++ b/src/reserved.c
@@ -906,14 +906,14 @@ void reserved_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	reservedIdx, aName, sizeof(reservedName));
-		send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",		aName->name, str_get_valid_display_value(aName->name));
-		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		aName->info.creator.name, str_get_valid_display_value(aName->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		aName->info.reason, str_get_valid_display_value(aName->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",	reservedIdx, (void *)aName, sizeof(reservedName));
+		send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",		(void *)aName->name, str_get_valid_display_value(aName->name));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		(void *)aName->info.creator.name, str_get_valid_display_value(aName->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)aName->info.reason, str_get_valid_display_value(aName->info.reason));
 		send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",		aName->info.creator.time);
 		send_notice_to_user(sourceNick, callerUser, "Flags: %#lx",					aName->flags);
 		send_notice_to_user(sourceNick, callerUser, "Last Update: %ld",				aName->lastUpdate);
-		send_notice_to_user(sourceNick, callerUser, "Next record: %p",				aName->next);
+		send_notice_to_user(sourceNick, callerUser, "Next record: %p",				(void *)aName->next);
 
 		if (sentIdx >= endIdx)
 			break;

--- a/src/reserved.c
+++ b/src/reserved.c
@@ -906,14 +906,14 @@ void reserved_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",	reservedIdx, (unsigned long)aName, sizeof(reservedName));
-		send_notice_to_user(sourceNick, callerUser, "Name: 0x%08X \2[\2%s\2]\2",		(unsigned long)aName->name, str_get_valid_display_value(aName->name));
-		send_notice_to_user(sourceNick, callerUser, "Creator: 0x%08X \2[\2%s\2]\2",		(unsigned long)aName->info.creator.name, str_get_valid_display_value(aName->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Reason: 0x%08X \2[\2%s\2]\2",		(unsigned long)aName->info.reason, str_get_valid_display_value(aName->info.reason));
-		send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",			aName->info.creator.time);
-		send_notice_to_user(sourceNick, callerUser, "Flags: %d",						aName->flags);
-		send_notice_to_user(sourceNick, callerUser, "Last Update: %ld",					aName->lastUpdate);
-		send_notice_to_user(sourceNick, callerUser, "Next record: 0x%08X",				(unsigned long)aName->next);
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	reservedIdx, aName, sizeof(reservedName));
+		send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",		aName->name, str_get_valid_display_value(aName->name));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		aName->info.creator.name, str_get_valid_display_value(aName->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		aName->info.reason, str_get_valid_display_value(aName->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",		aName->info.creator.time);
+		send_notice_to_user(sourceNick, callerUser, "Flags: %#lx",					aName->flags);
+		send_notice_to_user(sourceNick, callerUser, "Last Update: %ld",				aName->lastUpdate);
+		send_notice_to_user(sourceNick, callerUser, "Next record: %p",				aName->next);
 
 		if (sentIdx >= endIdx)
 			break;
@@ -949,6 +949,6 @@ unsigned long int reserved_mem_report(CSTR sourceNick, const User *callerUser) {
 		aName = aName->next;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Reserved Name List: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Reserved Name List: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	return mem;
 }

--- a/src/rootserv.c
+++ b/src/rootserv.c
@@ -1159,30 +1159,30 @@ static void do_dynconf(CSTR source, User *callerUser, ServiceCommandData *data) 
 
 								if (data->operMatch) {
 
-									LOG_SNOOP(s_OperServ, "RS D NS -- by %s (%s@%s) [%d]", callerUser->nick, callerUser->username, callerUser->host, value);
-									log_services(LOG_SERVICES_ROOTSERV, "D NS -- by %s (%s@%s) [%d]", callerUser->nick, callerUser->username, callerUser->host, value);
+									LOG_SNOOP(s_OperServ, "RS D NS -- by %s (%s@%s) [%lu]", callerUser->nick, callerUser->username, callerUser->host, value);
+									log_services(LOG_SERVICES_ROOTSERV, "D NS -- by %s (%s@%s) [%lu]", callerUser->nick, callerUser->username, callerUser->host, value);
 
 									send_globops(s_RootServ, "\2%s\2 set nick registration limit to \2%d\2", source, value);
 								}
 								else {
 
-									LOG_SNOOP(s_OperServ, "RS D NS -- by %s (%s@%s) through %s [%d]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
-									log_services(LOG_SERVICES_ROOTSERV, "D NS -- by %s (%s@%s) through %s [%d]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
+									LOG_SNOOP(s_OperServ, "RS D NS -- by %s (%s@%s) through %s [%lu]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
+									log_services(LOG_SERVICES_ROOTSERV, "D NS -- by %s (%s@%s) through %s [%lu]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
 
-									send_globops(s_RootServ, "\2%s\2 (through \2%s\2) set nick registration limit to \2%d\2", source, data->operName, value);
+									send_globops(s_RootServ, "\2%s\2 (through \2%s\2) set nick registration limit to \2%lu\2", source, data->operName, value);
 								}
 
-								send_notice_to_user(s_RootServ, callerUser, "\2%s\2 e' stato impostato a \2%d\2", option, value);
+								send_notice_to_user(s_RootServ, callerUser, "\2%s\2 has been set to \2%lu\2", option, value);
 							}
 							else {
 
 								TRACE_MAIN();
 								if (data->operMatch)
-									LOG_SNOOP(s_OperServ, "RS *D NS -- by %s (%s@%s) [%d < %d]", callerUser->nick, callerUser->username, callerUser->host, value, (ns_regCount + 25));
+									LOG_SNOOP(s_OperServ, "RS *D NS -- by %s (%s@%s) [%lu < %lu]", callerUser->nick, callerUser->username, callerUser->host, value, (ns_regCount + 25));
 								else
-									LOG_SNOOP(s_OperServ, "RS *D NS -- by %s (%s@%s) through %s [%d < %d]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value, (ns_regCount + 25));
+									LOG_SNOOP(s_OperServ, "RS *D NS -- by %s (%s@%s) through %s [%lu < %lu]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value, (ns_regCount + 25));
 
-								send_notice_to_user(s_RootServ, callerUser, "The given value is less than the current number of registered nicks! [%d < %d]", value, (ns_regCount + 25));
+								send_notice_to_user(s_RootServ, callerUser, "The given value is less than the current number of registered nicks! [%lu < %lu]", value, (ns_regCount + 25));
 							}
 						}
 						else {
@@ -1194,39 +1194,39 @@ static void do_dynconf(CSTR source, User *callerUser, ServiceCommandData *data) 
 
 								if (data->operMatch) {
 
-									LOG_SNOOP(s_OperServ, "RS D CS -- by %s (%s@%s) [%d]", callerUser->nick, callerUser->username, callerUser->host, value);
-									log_services(LOG_SERVICES_ROOTSERV, "D CS -- by %s (%s@%s) [%d]", callerUser->nick, callerUser->username, callerUser->host, value);
+									LOG_SNOOP(s_OperServ, "RS D CS -- by %s (%s@%s) [%lu]", callerUser->nick, callerUser->username, callerUser->host, value);
+									log_services(LOG_SERVICES_ROOTSERV, "D CS -- by %s (%s@%s) [%lu]", callerUser->nick, callerUser->username, callerUser->host, value);
 
-									send_globops(s_RootServ, "\2%s\2 set channel registration limit to \2%d\2", source, value);
+									send_globops(s_RootServ, "\2%s\2 set channel registration limit to \2%lu\2", source, value);
 								}
 								else {
 
-									LOG_SNOOP(s_OperServ, "RS D CS -- by %s (%s@%s) through %s [%d]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
-									log_services(LOG_SERVICES_ROOTSERV, "D CS -- by %s (%s@%s) through %s [%d]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
+									LOG_SNOOP(s_OperServ, "RS D CS -- by %s (%s@%s) through %s [%lu]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
+									log_services(LOG_SERVICES_ROOTSERV, "D CS -- by %s (%s@%s) through %s [%lu]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
 
-									send_globops(s_RootServ, "\2%s\2 (through \2%s\2) set channel registration limit to \2%d\2", source, data->operName, value);
+									send_globops(s_RootServ, "\2%s\2 (through \2%s\2) set channel registration limit to \2%lu\2", source, data->operName, value);
 								}
 
-								send_notice_to_user(s_RootServ, callerUser, "\2%s\2 e' stato impostato a \2%d\2", option, value);
+								send_notice_to_user(s_RootServ, callerUser, "\2%s\2 has been set to \2%lu\2", option, value);
 							}
 							else {
 
 								TRACE_MAIN();
 								if (data->operMatch)
-									LOG_SNOOP(s_OperServ, "RS *D CS -- by %s (%s@%s) [%d < %d]", callerUser->nick, callerUser->username, callerUser->host, value, (cs_regCount + 25));
+									LOG_SNOOP(s_OperServ, "RS *D CS -- by %s (%s@%s) [%lu < %lu]", callerUser->nick, callerUser->username, callerUser->host, value, (cs_regCount + 25));
 								else
-									LOG_SNOOP(s_OperServ, "RS *D CS -- by %s (%s@%s) through %s [%d < %d]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value, (cs_regCount + 25));
+									LOG_SNOOP(s_OperServ, "RS *D CS -- by %s (%s@%s) through %s [%lu < %lu]", callerUser->nick, callerUser->username, callerUser->host, data->operName, value, (cs_regCount + 25));
 
-								send_notice_to_user(s_RootServ, callerUser, "The given value is less than the current number of registered channels! [%d < %d]", value, (cs_regCount + 25));
+								send_notice_to_user(s_RootServ, callerUser, "The given value is less than the current number of registered channels! [%lu < %lu]", value, (cs_regCount + 25));
 							}
 						}
 					}
 					else {
 
 						if (data->operMatch)
-							LOG_SNOOP(s_OperServ, "RS *D %cS -- by %s (%s@%s) [%d < 0]", option[0], callerUser->nick, callerUser->username, callerUser->host, value);
+							LOG_SNOOP(s_OperServ, "RS *D %cS -- by %s (%s@%s) [%lu < 0]", option[0], callerUser->nick, callerUser->username, callerUser->host, value);
 						else
-							LOG_SNOOP(s_OperServ, "RS *D %cS -- by %s (%s@%s) through %s [%d < 0]", option[0], callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
+							LOG_SNOOP(s_OperServ, "RS *D %cS -- by %s (%s@%s) through %s [%lu < 0]", option[0], callerUser->nick, callerUser->username, callerUser->host, data->operName, value);
 
 						send_notice_to_user(s_RootServ, callerUser, "Value must be a positive number.");
 					}

--- a/src/rootserv.c
+++ b/src/rootserv.c
@@ -1274,7 +1274,7 @@ static void do_dynconf(CSTR source, User *callerUser, ServiceCommandData *data) 
 						send_notice_to_user(s_RootServ, callerUser, "Welcome Notice has been disabled.");
 					}
 					else if ((len = str_len(message)) > 400)
-						send_notice_to_user(s_RootServ, callerUser, "Welcome Notice cannot be longer than 400 characters (yours has: %lu).", len);
+						send_notice_to_user(s_RootServ, callerUser, "Welcome Notice cannot be longer than 400 characters (yours has: %zu).", len);
 
 					else {
 

--- a/src/rootserv.c
+++ b/src/rootserv.c
@@ -1162,7 +1162,7 @@ static void do_dynconf(CSTR source, User *callerUser, ServiceCommandData *data) 
 									LOG_SNOOP(s_OperServ, "RS D NS -- by %s (%s@%s) [%lu]", callerUser->nick, callerUser->username, callerUser->host, value);
 									log_services(LOG_SERVICES_ROOTSERV, "D NS -- by %s (%s@%s) [%lu]", callerUser->nick, callerUser->username, callerUser->host, value);
 
-									send_globops(s_RootServ, "\2%s\2 set nick registration limit to \2%d\2", source, value);
+									send_globops(s_RootServ, "\2%s\2 set nick registration limit to \2%lu\2", source, value);
 								}
 								else {
 

--- a/src/rootserv.c
+++ b/src/rootserv.c
@@ -1391,7 +1391,7 @@ void rootserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 		send_notice_to_user(sourceNick, callerUser, "ChanServ Registration Limit: %lu", dynConf.cs_regLimit);
 		send_notice_to_user(sourceNick, callerUser, "NickServ Registration Limit: %lu", dynConf.ns_regLimit);
-		send_notice_to_user(sourceNick, callerUser, "Welcome Notice: %p \2[\2%s\2]\2", dynConf.welcomeNotice, str_get_valid_display_value(dynConf.welcomeNotice));
+		send_notice_to_user(sourceNick, callerUser, "Welcome Notice: %p \2[\2%s\2]\2", (void *)dynConf.welcomeNotice, str_get_valid_display_value(dynConf.welcomeNotice));
 
 		LOG_DEBUG_SNOOP("Command: DUMP ROOTSERV DYNCONF -- by %s (%s@%s)", callerUser->nick, callerUser->username, callerUser->host);
 	}

--- a/src/rootserv.c
+++ b/src/rootserv.c
@@ -1274,7 +1274,7 @@ static void do_dynconf(CSTR source, User *callerUser, ServiceCommandData *data) 
 						send_notice_to_user(s_RootServ, callerUser, "Welcome Notice has been disabled.");
 					}
 					else if ((len = str_len(message)) > 400)
-						send_notice_to_user(s_RootServ, callerUser, "Welcome Notice cannot be longer than 400 characters (yours has: %d).", len);
+						send_notice_to_user(s_RootServ, callerUser, "Welcome Notice cannot be longer than 400 characters (yours has: %lu).", len);
 
 					else {
 
@@ -1323,7 +1323,7 @@ static void do_dynconf(CSTR source, User *callerUser, ServiceCommandData *data) 
 
 		TRACE_MAIN();
 		send_notice_to_user(s_RootServ, callerUser, "Current \2DynConf\2 settings:");
-		send_notice_to_user(s_RootServ, callerUser, "Registration limits: NS: \2%d\2 - CS: \2%d\2", dynConf.ns_regLimit, dynConf.cs_regLimit);
+		send_notice_to_user(s_RootServ, callerUser, "Registration limits: NS: \2%lu\2 - CS: \2%lu\2", dynConf.ns_regLimit, dynConf.cs_regLimit);
 		send_notice_to_user(s_RootServ, callerUser, "Welcome Notice: %s", dynConf.welcomeNotice ? dynConf.welcomeNotice : "<not set>");
 		send_notice_to_user(s_RootServ, callerUser, "*** \2End of List\2 ***");
 	}
@@ -1389,9 +1389,9 @@ void rootserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 		send_notice_to_user(sourceNick, callerUser, "DUMP: DynConf");
 
-		send_notice_to_user(sourceNick, callerUser, "ChanServ Registration Limit: %d", dynConf.cs_regLimit);
-		send_notice_to_user(sourceNick, callerUser, "NickServ Registration Limit: %d", dynConf.ns_regLimit);
-		send_notice_to_user(sourceNick, callerUser, "Welcome Notice: 0x%08X \2[\2%s\2]\2", (unsigned long)dynConf.welcomeNotice, str_get_valid_display_value(dynConf.welcomeNotice));
+		send_notice_to_user(sourceNick, callerUser, "ChanServ Registration Limit: %lu", dynConf.cs_regLimit);
+		send_notice_to_user(sourceNick, callerUser, "NickServ Registration Limit: %lu", dynConf.ns_regLimit);
+		send_notice_to_user(sourceNick, callerUser, "Welcome Notice: %p \2[\2%s\2]\2", dynConf.welcomeNotice, str_get_valid_display_value(dynConf.welcomeNotice));
 
 		LOG_DEBUG_SNOOP("Command: DUMP ROOTSERV DYNCONF -- by %s (%s@%s)", callerUser->nick, callerUser->username, callerUser->host);
 	}
@@ -1430,7 +1430,7 @@ unsigned long int rootserv_mem_report(CSTR sourceNick, const User *callerUser) {
 	/* Server bot list */
 	mem = access_mem_report(serverBotList, &count);
 
-	send_notice_to_user(sourceNick, callerUser, "Server BOT-list: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Server BOT-list: \2%d\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 
 	return mem;
 }

--- a/src/seenserv.c
+++ b/src/seenserv.c
@@ -477,20 +477,18 @@ void seenserv_expire_records() {
 	}
 
 	if (CONF_DISPLAY_UPDATES)
-		send_globops(NULL, "Completed Seen Records Expire (%d/%d)", xcount, count);
+		send_globops(NULL, "Completed Seen Records Expire (%ld/%ld)", xcount, count);
 	else
-		LOG_SNOOP(s_OperServ, "Completed Seen Records Expire (%d/%d)", xcount, count);
+		LOG_SNOOP(s_OperServ, "Completed Seen Records Expire (%ld/%ld)", xcount, count);
 }
 
 
 void seenserv_weekly_expire() {
 
 	#ifdef	FIX_USE_MPOOL
-	unsigned int	count;
+	unsigned int	count = mempool_garbage_collect(seen_nickseen_mempool);
 
-	count = mempool_garbage_collect(seen_nickseen_mempool);
-
-	LOG_DEBUG_SNOOP("\2MPGC\2 Seens:\2 %d\2 blocks collected", count);
+	LOG_DEBUG_SNOOP("\2MPGC\2 Seens:\2 %u\2 blocks collected", count);
 	#endif
 
 	if (CONF_DISPLAY_UPDATES)
@@ -1597,7 +1595,7 @@ void seenserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					send_notice_to_user(sourceNick, callerUser, "%05d) ADR\2 0x%08X\2 - NXT\2 0x%08X\2 - PRV\2 0x%08X\2 - KEY \2%s\2", idx, (unsigned long)si, (unsigned long)si->next, (unsigned long)si->prev, str_get_valid_display_value(si->nick));
 			}
 
-			LOG_DEBUG_SNOOP("Command: DUMP SEENSERV HASHTABLE %d %d %d -- by %s (%s@%s)", hashIdx, startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
+			LOG_DEBUG_SNOOP("Command: DUMP SEENSERV HASHTABLE %ld %ld %ld -- by %s (%s@%s)", hashIdx, startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
 		}
 		else
 			needSyntax = TRUE;

--- a/src/seenserv.c
+++ b/src/seenserv.c
@@ -1521,7 +1521,7 @@ void seenserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				send_notice_to_user(sourceNick, callerUser, "DUMP: Seen record for \2%s\2:", nick);
 
-				send_notice_to_user(sourceNick, callerUser, "Address %ps, size %zu B",				(void *)si, sizeof(SeenInfo) + str_len(si->nick) + str_len(si->username) + str_len(si->host) + str_len(si->realname) + str_len(si->tempnick) + str_len(si->quitmsg) + 6);
+				send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",				(void *)si, sizeof(SeenInfo) + str_len(si->nick) + str_len(si->username) + str_len(si->host) + str_len(si->realname) + str_len(si->tempnick) + str_len(si->quitmsg) + 6);
 				send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",				(void *)si->nick, str_get_valid_display_value(si->nick));
 				send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",			(void *)si->username, str_get_valid_display_value(si->username));
 				send_notice_to_user(sourceNick, callerUser, "Realname: %p \2[\2%s\2]\2",			(void *)si->realname, str_get_valid_display_value(si->realname));

--- a/src/seenserv.c
+++ b/src/seenserv.c
@@ -1521,11 +1521,11 @@ void seenserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				send_notice_to_user(sourceNick, callerUser, "DUMP: Seen record for \2%s\2:", nick);
 
-				send_notice_to_user(sourceNick, callerUser, "Address %ps, size %lu B",				si, sizeof(SeenInfo) + str_len(si->nick) + str_len(si->username) + str_len(si->host) + str_len(si->realname) + str_len(si->tempnick) + str_len(si->quitmsg) + 6);
-				send_notice_to_user(sourceNick, callerUser, "Name: %ps \2[\2%s\2]\2",				si->nick, str_get_valid_display_value(si->nick));
-				send_notice_to_user(sourceNick, callerUser, "Username: %ps \2[\2%s\2]\2",			si->username, str_get_valid_display_value(si->username));
-				send_notice_to_user(sourceNick, callerUser, "Realname: %ps \2[\2%s\2]\2",			si->realname, str_get_valid_display_value(si->realname));
-				send_notice_to_user(sourceNick, callerUser, "Host: %ps \2[\2%s\2]\2",				si->host, str_get_valid_display_value(si->host));
+				send_notice_to_user(sourceNick, callerUser, "Address %ps, size %zu B",				(void *)si, sizeof(SeenInfo) + str_len(si->nick) + str_len(si->username) + str_len(si->host) + str_len(si->realname) + str_len(si->tempnick) + str_len(si->quitmsg) + 6);
+				send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",				(void *)si->nick, str_get_valid_display_value(si->nick));
+				send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",			(void *)si->username, str_get_valid_display_value(si->username));
+				send_notice_to_user(sourceNick, callerUser, "Realname: %p \2[\2%s\2]\2",			(void *)si->realname, str_get_valid_display_value(si->realname));
+				send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",				(void *)si->host, str_get_valid_display_value(si->host));
 
 				#ifdef ENABLE_CAPAB_NICKIP
 				send_notice_to_user(sourceNick, callerUser, "IP from NICKIP: %#x \2[\2%s\2]\2",		si->ip, get_ip(si->ip));
@@ -1533,10 +1533,10 @@ void seenserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				send_notice_to_user(sourceNick, callerUser, "User Modes: %d",						si->mode);
 				send_notice_to_user(sourceNick, callerUser, "Type: %d",								(int)si->type);
-				send_notice_to_user(sourceNick, callerUser, "Temp Nick: %ps \2[\2%s\2]\2",			si->tempnick, str_get_valid_display_value(si->tempnick));
-				send_notice_to_user(sourceNick, callerUser, "Quit Message: %ps \2[\2%s\2]\2",		si->quitmsg, str_get_valid_display_value(si->quitmsg));
+				send_notice_to_user(sourceNick, callerUser, "Temp Nick: %p \2[\2%s\2]\2",			(void *)si->tempnick, str_get_valid_display_value(si->tempnick));
+				send_notice_to_user(sourceNick, callerUser, "Quit Message: %p \2[\2%s\2]\2",		(void *)si->quitmsg, str_get_valid_display_value(si->quitmsg));
 				send_notice_to_user(sourceNick, callerUser, "Last seen C-time: %ld",				si->last_seen);
-				send_notice_to_user(sourceNick, callerUser, "Next / previous record: %ps / %ps",	si->next, si->prev);
+				send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",		(void *)si->next, (void *)si->prev);
 
 				LOG_DEBUG_SNOOP("Command: DUMP SEENSERV NICK %s -- by %s (%s@%s)", nick, callerUser->nick, callerUser->username, callerUser->host);
 			}
@@ -1592,7 +1592,7 @@ void seenserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			for (idx = 0, si = hashtable_seeninfo[hashIdx]; IS_NOT_NULL(si) && (idx <= endIdx); ++idx, si = si->next) {
 
 				if (idx >= startIdx)
-					send_notice_to_user(sourceNick, callerUser, "%05ld) ADR\2 %p\2 - NXT\2 %p\2 - PRV\2 %p\2 - KEY \2%s\2", idx, si, si->next, si->prev, str_get_valid_display_value(si->nick));
+					send_notice_to_user(sourceNick, callerUser, "%05ld) ADR\2 %p\2 - NXT\2 %p\2 - PRV\2 %p\2 - KEY \2%s\2", idx, (void *)si, (void *)si->next, (void *)si->prev, str_get_valid_display_value(si->nick));
 			}
 
 			LOG_DEBUG_SNOOP("Command: DUMP SEENSERV HASHTABLE %ld %ld %ld -- by %s (%s@%s)", hashIdx, startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
@@ -1607,7 +1607,7 @@ void seenserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 		MemoryPoolStats pstats;
 
 		mempool_stats(seen_nickseen_mempool, &pstats);
-		send_notice_to_user(sourceNick, callerUser, "DUMP: SeenServ nickseen memory pool - Address %p, ID: %u",	seen_nickseen_mempool, pstats.id);
+		send_notice_to_user(sourceNick, callerUser, "DUMP: SeenServ nickseen memory pool - Address %p, ID: %u",	(void *)seen_nickseen_mempool, pstats.id);
 		send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",					pstats.memory_allocated, pstats.memory_free);
 		send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",						pstats.items_allocated, pstats.items_free);
 		send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",					pstats.items_per_block, pstats.block_count);

--- a/src/seenserv.c
+++ b/src/seenserv.c
@@ -1428,7 +1428,7 @@ proceed:
 				snprintf(reply, sizeof(reply), lang_msg(GetCallerLang(), SS_SEEN_REPLY_MANY), count, max_hits);
 
 			else if (count == 1)
-				snprintf(reply, sizeof(reply), lang_msg(GetCallerLang(), SS_SEEN_REPLY_ONE));
+				snprintf(reply, sizeof(reply), "%s", lang_msg(GetCallerLang(), SS_SEEN_REPLY_ONE)); /* FIXME: prevent false positive for format-security, should go away if/when we move lang stuff to gettext */
 
 			else
 				snprintf(reply, sizeof(reply), lang_msg(GetCallerLang(), SS_SEEN_REPLY_SOME), count);

--- a/src/seenserv.c
+++ b/src/seenserv.c
@@ -817,7 +817,7 @@ static void do_seennick(CSTR source, User *callerUser, ServiceCommandData *data)
 		TRACE_MAIN();
 
 		send_notice_lang_to_user(s_SeenServ, callerUser, GetCallerLang(), SS_SEENNICK_HEADER, si->nick);
-		send_notice_to_user(s_SeenServ, callerUser, s_SPACE);
+		send_notice_to_user(s_SeenServ, callerUser, " ");
 
 		send_seen_info(si, callerUser);
 
@@ -862,7 +862,7 @@ static void do_seennick(CSTR source, User *callerUser, ServiceCommandData *data)
 		TRACE_MAIN();
 		if (!isOper) {
 
-			send_notice_to_user(s_SeenServ, callerUser, s_SPACE);
+			send_notice_to_user(s_SeenServ, callerUser, " ");
 			send_notice_lang_to_user(s_SeenServ, callerUser, GetCallerLang(), END_OF_SEEN);
 			return;
 		}
@@ -932,18 +932,18 @@ static void do_seenstats(CSTR source, User *callerUser, ServiceCommandData *data
 
 	TRACE_MAIN();
 	send_notice_to_user(s_SeenServ, callerUser, "\2*** SeenServ Records Status ***\2");
-	send_notice_to_user(s_SeenServ, callerUser, s_SPACE);
-	send_notice_to_user(s_SeenServ, callerUser, "Currently tracking %ld seen records.", nicks + quits + nc + kills + splits + noseen);
-	send_notice_to_user(s_SeenServ, callerUser, s_SPACE);
-	send_notice_to_user(s_SeenServ, callerUser, "Nicks: \2%d\2", nicks);
-	send_notice_to_user(s_SeenServ, callerUser, "Quits: \2%d\2", quits);
-	send_notice_to_user(s_SeenServ, callerUser, "Nick Changes: \2%d\2", nc);
-	send_notice_to_user(s_SeenServ, callerUser, "Kills: \2%d\2", kills);
-	send_notice_to_user(s_SeenServ, callerUser, "Splits: \2%d\2", splits);
-	send_notice_to_user(s_SeenServ, callerUser, "No Seen: \2%d\2", noseen);
-	send_notice_to_user(s_SeenServ, callerUser, "Autokills: \2%d\2", akill);
-	send_notice_to_user(s_SeenServ, callerUser, "K-Lines: \2%d\2", kline);
-	send_notice_to_user(s_SeenServ, callerUser, s_SPACE);
+	send_notice_to_user(s_SeenServ, callerUser, " ");
+	send_notice_to_user(s_SeenServ, callerUser, "Currently tracking %lu seen records.", nicks + quits + nc + kills + splits + noseen);
+	send_notice_to_user(s_SeenServ, callerUser, " ");
+	send_notice_to_user(s_SeenServ, callerUser, "Nicks: \2%lu\2", nicks);
+	send_notice_to_user(s_SeenServ, callerUser, "Quits: \2%lu\2", quits);
+	send_notice_to_user(s_SeenServ, callerUser, "Nick Changes: \2%lu\2", nc);
+	send_notice_to_user(s_SeenServ, callerUser, "Kills: \2%lu\2", kills);
+	send_notice_to_user(s_SeenServ, callerUser, "Splits: \2%lu\2", splits);
+	send_notice_to_user(s_SeenServ, callerUser, "No Seen: \2%lu\2", noseen);
+	send_notice_to_user(s_SeenServ, callerUser, "Autokills: \2%lu\2", akill);
+	send_notice_to_user(s_SeenServ, callerUser, "K-Lines: \2%lu\2", kline);
+	send_notice_to_user(s_SeenServ, callerUser, " ");
 	send_notice_to_user(s_SeenServ, callerUser, "\2*** End of Seen Stats***\2");
 }
 
@@ -1452,7 +1452,7 @@ proceed:
 			*(reply + len) = c_NULL;
 
 			TRACE_MAIN();
-			send_notice_to_user(s_SeenServ, callerUser, reply);
+			send_notice_to_user(s_SeenServ, callerUser, "%s", reply);
 
 			if (!isOper && IS_NOT_NULL(user = hash_onlineuser_find(matches[0]->nick))) {
 
@@ -1521,22 +1521,22 @@ void seenserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				send_notice_to_user(sourceNick, callerUser, "DUMP: Seen record for \2%s\2:", nick);
 
-				send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",						(unsigned long)si, sizeof(SeenInfo) + str_len(si->nick) + str_len(si->username) + str_len(si->host) + str_len(si->realname) + str_len(si->tempnick) + str_len(si->quitmsg) + 6);
-				send_notice_to_user(sourceNick, callerUser, "Name: 0x%08X \2[\2%s\2]\2",						(unsigned long)si->nick, str_get_valid_display_value(si->nick));
-				send_notice_to_user(sourceNick, callerUser, "Username: 0x%08X \2[\2%s\2]\2",					(unsigned long)si->username, str_get_valid_display_value(si->username));
-				send_notice_to_user(sourceNick, callerUser, "Realname: 0x%08X \2[\2%s\2]\2",					(unsigned long)si->realname, str_get_valid_display_value(si->realname));
-				send_notice_to_user(sourceNick, callerUser, "Host: 0x%08X \2[\2%s\2]\2",						(unsigned long)si->host, str_get_valid_display_value(si->host));
+				send_notice_to_user(sourceNick, callerUser, "Address %ps, size %lu B",				si, sizeof(SeenInfo) + str_len(si->nick) + str_len(si->username) + str_len(si->host) + str_len(si->realname) + str_len(si->tempnick) + str_len(si->quitmsg) + 6);
+				send_notice_to_user(sourceNick, callerUser, "Name: %ps \2[\2%s\2]\2",				si->nick, str_get_valid_display_value(si->nick));
+				send_notice_to_user(sourceNick, callerUser, "Username: %ps \2[\2%s\2]\2",			si->username, str_get_valid_display_value(si->username));
+				send_notice_to_user(sourceNick, callerUser, "Realname: %ps \2[\2%s\2]\2",			si->realname, str_get_valid_display_value(si->realname));
+				send_notice_to_user(sourceNick, callerUser, "Host: %ps \2[\2%s\2]\2",				si->host, str_get_valid_display_value(si->host));
 
 				#ifdef ENABLE_CAPAB_NICKIP
-				send_notice_to_user(sourceNick, callerUser, "IP from NICKIP: 0x%08X \2[\2%lu\2]\2",				si->ip, si->ip);
+				send_notice_to_user(sourceNick, callerUser, "IP from NICKIP: %#x \2[\2%s\2]\2",		si->ip, get_ip(si->ip));
 				#endif
 
-				send_notice_to_user(sourceNick, callerUser, "User Modes: %d",									si->mode);
-				send_notice_to_user(sourceNick, callerUser, "Type: %d",											(int)si->type);
-				send_notice_to_user(sourceNick, callerUser, "Temp Nick: 0x%08X \2[\2%s\2]\2",					(unsigned long)si->tempnick, str_get_valid_display_value(si->tempnick));
-				send_notice_to_user(sourceNick, callerUser, "Quit Message: 0x%08X \2[\2%s\2]\2",				(unsigned long)si->quitmsg, str_get_valid_display_value(si->quitmsg));
-				send_notice_to_user(sourceNick, callerUser, "Last seen C-time: %d",								si->last_seen);
-				send_notice_to_user(sourceNick, callerUser, "Next / previous record: 0x%08X / 0x%08X",			(unsigned long)si->next, (unsigned long)si->prev);
+				send_notice_to_user(sourceNick, callerUser, "User Modes: %d",						si->mode);
+				send_notice_to_user(sourceNick, callerUser, "Type: %d",								(int)si->type);
+				send_notice_to_user(sourceNick, callerUser, "Temp Nick: %ps \2[\2%s\2]\2",			si->tempnick, str_get_valid_display_value(si->tempnick));
+				send_notice_to_user(sourceNick, callerUser, "Quit Message: %ps \2[\2%s\2]\2",		si->quitmsg, str_get_valid_display_value(si->quitmsg));
+				send_notice_to_user(sourceNick, callerUser, "Last seen C-time: %ld",				si->last_seen);
+				send_notice_to_user(sourceNick, callerUser, "Next / previous record: %ps / %ps",	si->next, si->prev);
 
 				LOG_DEBUG_SNOOP("Command: DUMP SEENSERV NICK %s -- by %s (%s@%s)", nick, callerUser->nick, callerUser->username, callerUser->host);
 			}
@@ -1592,7 +1592,7 @@ void seenserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			for (idx = 0, si = hashtable_seeninfo[hashIdx]; IS_NOT_NULL(si) && (idx <= endIdx); ++idx, si = si->next) {
 
 				if (idx >= startIdx)
-					send_notice_to_user(sourceNick, callerUser, "%05d) ADR\2 0x%08X\2 - NXT\2 0x%08X\2 - PRV\2 0x%08X\2 - KEY \2%s\2", idx, (unsigned long)si, (unsigned long)si->next, (unsigned long)si->prev, str_get_valid_display_value(si->nick));
+					send_notice_to_user(sourceNick, callerUser, "%05ld) ADR\2 %p\2 - NXT\2 %p\2 - PRV\2 %p\2 - KEY \2%s\2", idx, si, si->next, si->prev, str_get_valid_display_value(si->nick));
 			}
 
 			LOG_DEBUG_SNOOP("Command: DUMP SEENSERV HASHTABLE %ld %ld %ld -- by %s (%s@%s)", hashIdx, startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
@@ -1607,11 +1607,11 @@ void seenserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 		MemoryPoolStats pstats;
 
 		mempool_stats(seen_nickseen_mempool, &pstats);
-		send_notice_to_user(sourceNick, callerUser, "DUMP: SeenServ nickseen memory pool - Address 0x%08X, ID: %d",	(unsigned long)seen_nickseen_mempool, pstats.id);
-		send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %d B / %d B",				pstats.memory_allocated, pstats.memory_free);
-		send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %d / %d",					pstats.items_allocated, pstats.items_free);
-		send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %d / %d",			pstats.items_per_block, pstats.block_count);
-		//send_notice_to_user(sourceNick, callerUser, "Average use: %.2f%%",							pstats.block_avg_usage);
+		send_notice_to_user(sourceNick, callerUser, "DUMP: SeenServ nickseen memory pool - Address %p, ID: %u",	seen_nickseen_mempool, pstats.id);
+		send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",					pstats.memory_allocated, pstats.memory_free);
+		send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",						pstats.items_allocated, pstats.items_free);
+		send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",					pstats.items_per_block, pstats.block_count);
+		//send_notice_to_user(sourceNick, callerUser, "Average use: %.2f%%",									pstats.block_avg_usage);
 
 		LOG_DEBUG_SNOOP("Command: DUMP SEENSERV POOLSTAT -- by %s (%s@%s)", callerUser->nick, callerUser->username, callerUser->host);
 	}
@@ -1677,7 +1677,7 @@ unsigned long seenserv_mem_report(CSTR sourceNick, const User *callerUser) {
 	TRACE();
 	mem_total = mem;
 
-	send_notice_to_user(sourceNick, callerUser, "Seen records: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Seen records: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 
 	return mem_total;
 }

--- a/src/send.c
+++ b/src/send.c
@@ -55,8 +55,8 @@ void send_cmd(CSTR fmt, ...) {
 	++total_sendM;
 
 	va_start(args, fmt);
-
 	len = vsnprintf(cmd_buffer, IRCBUFSIZE, fmt, args);
+	va_end(args);
 
 	if (len < 0)
 		len = IRCBUFSIZE;
@@ -68,8 +68,6 @@ void send_cmd(CSTR fmt, ...) {
 	cmd_buffer[len] = '\0';
 
 	socket_write(cmd_buffer, len);
-
-	va_end(args);
 }
 
 /* Globals */
@@ -79,8 +77,8 @@ void send_globops(CSTR source, CSTR fmt, ...) {
 
 	va_start(args, fmt);
 	vsnprintf(send_local_buffer, IRCBUFSIZE, fmt, args);
-	send_cmd(":%s GLOBOPS :%s", source ? source : CONF_SERVICES_NAME, send_local_buffer);
 	va_end(args);
+	send_cmd(":%s GLOBOPS :%s", source ? source : CONF_SERVICES_NAME, send_local_buffer);
 }
 
 void send_chatops(CSTR source, CSTR fmt, ...) {
@@ -89,8 +87,8 @@ void send_chatops(CSTR source, CSTR fmt, ...) {
 
 	va_start(args, fmt);
 	vsnprintf(send_local_buffer, IRCBUFSIZE, fmt, args);
-	send_cmd(":%s CHATOPS :%s", source ? source : CONF_SERVICES_NAME, send_local_buffer);
 	va_end(args);
+	send_cmd(":%s CHATOPS :%s", source ? source : CONF_SERVICES_NAME, send_local_buffer);
 }
 
 void send_SPAMOPS(CSTR source, CSTR fmt, ...) {
@@ -99,8 +97,8 @@ void send_SPAMOPS(CSTR source, CSTR fmt, ...) {
 
 	va_start(args, fmt);
 	vsnprintf(send_local_buffer, IRCBUFSIZE, fmt, args);
-	send_cmd(":%s SNOTICE :%s", source ? source : CONF_SERVICES_NAME, send_local_buffer);
 	va_end(args);
+	send_cmd(":%s SNOTICE :%s", source ? source : CONF_SERVICES_NAME, send_local_buffer);
 }
 
 
@@ -114,8 +112,8 @@ void send_notice_to_nick(CSTR source, CSTR dest, CSTR fmt, ...) {
 
 	va_start(args, fmt);
 	vsnprintf(send_local_buffer, IRCBUFSIZE, fmt, args);
-	send_cmd(":%s NOTICE %s :%s", source, dest, send_local_buffer);
 	va_end(args);
+	send_cmd(":%s NOTICE %s :%s", source, dest, send_local_buffer);
 }
 
 
@@ -129,8 +127,8 @@ void send_notice_to_user(CSTR source, const User *dest, CSTR fmt, ...) {
 
 	va_start(args, fmt);
 	vsnprintf(send_local_buffer, IRCBUFSIZE, fmt, args);
-	send_cmd(":%s NOTICE %s :%s", source, dest->nick, send_local_buffer);
 	va_end(args);
+	send_cmd(":%s NOTICE %s :%s", source, dest->nick, send_local_buffer);
 }
 
 void send_notice_lang_to_nick(CSTR source, CSTR dest, const LANG_ID lang_id, const LANG_MSG_ID msg_id, ...) {
@@ -144,10 +142,10 @@ void send_notice_lang_to_nick(CSTR source, CSTR dest, const LANG_ID lang_id, con
 	if (nick_is_service(dest)) // non mandiamoci messaggi da soli che non e' il caso ...
 		return;
 	
-	va_start(args, msg_id);
-
 	memset(buffer, 0, sizeof(buffer));
+	va_start(args, msg_id);
 	vsnprintf(buffer, sizeof(buffer), fmt, args);
+	va_end(args);
 
 	row_end = buffer;
 
@@ -161,8 +159,6 @@ void send_notice_lang_to_nick(CSTR source, CSTR dest, const LANG_ID lang_id, con
 
 		send_cmd(":%s NOTICE %s :%s", source, dest, *row ? row : s_SPACE);
 	}
-
-	va_end(args);
 }
 
 void send_notice_lang_to_user(CSTR source, const User *dest, const LANG_ID lang_id, const LANG_MSG_ID msg_id, ...) {
@@ -175,10 +171,10 @@ void send_notice_lang_to_user(CSTR source, const User *dest, const LANG_ID lang_
 	if (user_is_services_client(dest)) // non mandiamoci messaggi da soli che non e' il caso ...
 		return;
 	
-	va_start(args, msg_id);
-
 	memset(buffer, 0, sizeof(buffer));
+	va_start(args, msg_id);
 	vsnprintf(buffer, sizeof(buffer), fmt, args);
+	va_end(args);
 
 	row_end = buffer;
 
@@ -192,8 +188,6 @@ void send_notice_lang_to_user(CSTR source, const User *dest, const LANG_ID lang_
 
 		send_cmd(":%s NOTICE %s :%s", source, dest->nick, *row ? row : s_SPACE);
 	}
-
-	va_end(args);
 }
 
 /* Remove a user from the IRC network. 'source' is the nick which should generate the kill. */
@@ -231,8 +225,8 @@ void send_PRIVMSG(CSTR source, CSTR dest, CSTR fmt, ...) {
 
 	va_start(args, fmt);
 	vsnprintf(send_local_buffer, IRCBUFSIZE, fmt, args);
-	send_cmd(":%s PRIVMSG %s :%s", source, dest, send_local_buffer);
 	va_end(args);
+	send_cmd(":%s PRIVMSG %s :%s", source, dest, send_local_buffer);
 }
 
 /* Send a NICK from services, and fake the client loading. */

--- a/src/send.c
+++ b/src/send.c
@@ -321,7 +321,7 @@ void send_AKILL(CSTR username, CSTR host, CSTR who, CSTR reason, const unsigned 
 
 	snprintf(buffer, sizeof(buffer), "%s [AKill ID: %lu-%s]", reason, id, type);
 
-	send_cmd("AKILL %s %s 0 %s %lu :%s", host, username, who, time(NULL), buffer);
+	send_cmd("AKILL %s %s 0 %s %ld :%s", host, username, who, time(NULL), buffer);
 }
 
 /* Remove an AutoKill. */

--- a/src/servers.c
+++ b/src/servers.c
@@ -793,16 +793,16 @@ void server_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				send_notice_to_user(sourceNick, callerUser, "DUMP: Server \2%s\2", value);
 
-				send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			server, sizeof(Server) + str_len(server->name) + str_len(server->desc) + 2);
-				send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			server->name, str_get_valid_display_value(server->name));
-				send_notice_to_user(sourceNick, callerUser, "Desc: %p \2[\2%s\2]\2",			server->desc, str_get_valid_display_value(server->desc));
-				send_notice_to_user(sourceNick, callerUser, "Uplink: %p \2[\2%s\2]\2",			server->uplink, str_get_valid_display_value(server->uplink->name));
+				send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",			(void *)server, sizeof(Server) + str_len(server->name) + str_len(server->desc) + 2);
+				send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			(void *)server->name, str_get_valid_display_value(server->name));
+				send_notice_to_user(sourceNick, callerUser, "Desc: %p \2[\2%s\2]\2",			(void *)server->desc, str_get_valid_display_value(server->desc));
+				send_notice_to_user(sourceNick, callerUser, "Uplink: %p \2[\2%s\2]\2",			(void *)server->uplink, str_get_valid_display_value(server->uplink->name));
 				send_notice_to_user(sourceNick, callerUser, "Hops: %u",							server->hops);
 				send_notice_to_user(sourceNick, callerUser, "Users: %u",						server->userCount);
 				send_notice_to_user(sourceNick, callerUser, "Connected C-time: %ld",			server->connected);
 				send_notice_to_user(sourceNick, callerUser, "Flags: %d",						server->flags);
-				send_notice_to_user(sourceNick, callerUser, "Stats: %p",						server->stats);
-				send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	server->next, server->prev);
+				send_notice_to_user(sourceNick, callerUser, "Stats: %p",						(void *)server->stats);
+				send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	(void *)server->next, (void *)server->prev);
 
 				LOG_DEBUG_SNOOP("Command: DUMP SERVER %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 			}

--- a/src/servers.c
+++ b/src/servers.c
@@ -651,7 +651,7 @@ void send_servers_list(CSTR sourceNick, const User *callerUser) {
 	TRACE_FCLT(FACILITY_SERVERS_SEND_LIST);
 
 	send_notice_to_user(sourceNick, callerUser, "Current servers list:");
-	send_notice_to_user(sourceNick, callerUser, s_SPACE);
+	send_notice_to_user(sourceNick, callerUser, " ");
 
 	for (serverIdx = FIRST_VALID_HOST_CHAR; serverIdx <= LAST_VALID_HOST_CHAR; ++serverIdx) {
 
@@ -669,7 +669,7 @@ void send_servers_list(CSTR sourceNick, const User *callerUser) {
 		}
 	}
 
-	send_notice_to_user(sourceNick, callerUser, s_SPACE);
+	send_notice_to_user(sourceNick, callerUser, " ");
 	send_notice_to_user(sourceNick, callerUser, "\2*** End of Servers ***\2");
 }
 
@@ -793,16 +793,16 @@ void server_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				send_notice_to_user(sourceNick, callerUser, "DUMP: Server \2%s\2", value);
 
-				send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",						(unsigned long)server, sizeof(Server) + str_len(server->name) + str_len(server->desc) + 2);
-				send_notice_to_user(sourceNick, callerUser, "Name: 0x%08X \2[\2%s\2]\2",						(unsigned long)server->name, str_get_valid_display_value(server->name));
-				send_notice_to_user(sourceNick, callerUser, "Desc: 0x%08X \2[\2%s\2]\2",						(unsigned long)server->desc, str_get_valid_display_value(server->desc));
-				send_notice_to_user(sourceNick, callerUser, "Uplink: 0x%08X \2[\2%s\2]\2",						(unsigned long)server->uplink, str_get_valid_display_value(server->uplink->name));
-				send_notice_to_user(sourceNick, callerUser, "Hops: %u",											server->hops);
-				send_notice_to_user(sourceNick, callerUser, "Users: %u",										server->userCount);
-				send_notice_to_user(sourceNick, callerUser, "Connected C-time: %ld",							server->connected);
-				send_notice_to_user(sourceNick, callerUser, "Flags: %ld",										server->flags);
-				send_notice_to_user(sourceNick, callerUser, "Stats: 0x%08X",									(unsigned long)server->stats);
-				send_notice_to_user(sourceNick, callerUser, "Next / previous record: 0x%08X / 0x%08X",			(unsigned long)server->next, (unsigned long)server->prev);
+				send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			server, sizeof(Server) + str_len(server->name) + str_len(server->desc) + 2);
+				send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			server->name, str_get_valid_display_value(server->name));
+				send_notice_to_user(sourceNick, callerUser, "Desc: %p \2[\2%s\2]\2",			server->desc, str_get_valid_display_value(server->desc));
+				send_notice_to_user(sourceNick, callerUser, "Uplink: %p \2[\2%s\2]\2",			server->uplink, str_get_valid_display_value(server->uplink->name));
+				send_notice_to_user(sourceNick, callerUser, "Hops: %u",							server->hops);
+				send_notice_to_user(sourceNick, callerUser, "Users: %u",						server->userCount);
+				send_notice_to_user(sourceNick, callerUser, "Connected C-time: %ld",			server->connected);
+				send_notice_to_user(sourceNick, callerUser, "Flags: %d",						server->flags);
+				send_notice_to_user(sourceNick, callerUser, "Stats: %p",						server->stats);
+				send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	server->next, server->prev);
 
 				LOG_DEBUG_SNOOP("Command: DUMP SERVER %s -- by %s (%s@%s)", value, callerUser->nick, callerUser->username, callerUser->host);
 			}
@@ -870,6 +870,6 @@ unsigned long server_mem_report(CSTR sourceNick, const User *callerUser) {
 		}
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Server list: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Server list: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	return mem;
 }

--- a/src/spam.c
+++ b/src/spam.c
@@ -491,13 +491,13 @@ void handle_spam(CSTR source, User *callerUser, ServiceCommandData *data) {
 					send_SPAM(spamtext, type, reason);
 
 					if (data->operMatch) {
-						LOG_SNOOP(data->agent->nick, "%s +SP %s -- by %s (%s@%s) [Type: %d - Reason: %s]", data->agent->shortNick, spamtext, callerUser->nick, callerUser->username, callerUser->host, type, reason);
-						log_services(data->agent->logID, "+SP %s -- by %s (%s@%s) [Type: %d - Reason: %s]", spamtext, callerUser->nick, callerUser->username, callerUser->host, type, reason);
-						send_SPAMOPS(data->agent->nick, "\2%s\2 added a new SPAM [Text: \2%s\2] [Type: %d] [Reason: %s]", source, spamtext, type, reason);
+						LOG_SNOOP(data->agent->nick, "%s +SP %s -- by %s (%s@%s) [Type: %ld - Reason: %s]", data->agent->shortNick, spamtext, callerUser->nick, callerUser->username, callerUser->host, type, reason);
+						log_services(data->agent->logID, "+SP %s -- by %s (%s@%s) [Type: %ld - Reason: %s]", spamtext, callerUser->nick, callerUser->username, callerUser->host, type, reason);
+						send_SPAMOPS(data->agent->nick, "\2%s\2 added a new SPAM [Text: \2%s\2] [Type: %ld] [Reason: %s]", source, spamtext, type, reason);
 					} else {
-						LOG_SNOOP(data->agent->nick, "%s +SP %s -- by %s (%s@%s) through %s [Type: %d - Reason: %s]", data->agent->shortNick, spamtext, callerUser->nick, callerUser->username, callerUser->host, data->operName, type, reason);
-						log_services(data->agent->logID, "+SP %s -- by %s (%s@%s) through %s [Type: %d - Reason: %s]", spamtext, callerUser->nick, callerUser->username, callerUser->host, data->operName, type, reason);
-						send_SPAMOPS(data->agent->nick, "\2%s\2 (through \2%s\2) added a new SPAM [Text: \2%s\2] [Type: %d] [Reason: %s]", source, data->operName, spamtext, type, reason);
+						LOG_SNOOP(data->agent->nick, "%s +SP %s -- by %s (%s@%s) through %s [Type: %ld - Reason: %s]", data->agent->shortNick, spamtext, callerUser->nick, callerUser->username, callerUser->host, data->operName, type, reason);
+						log_services(data->agent->logID, "+SP %s -- by %s (%s@%s) through %s [Type: %ld - Reason: %s]", spamtext, callerUser->nick, callerUser->username, callerUser->host, data->operName, type, reason);
+						send_SPAMOPS(data->agent->nick, "\2%s\2 (through \2%s\2) added a new SPAM [Text: \2%s\2] [Type: %ld] [Reason: %s]", source, data->operName, spamtext, type, reason);
 					}
 
 					send_notice_to_user(data->agent->nick, callerUser, "\2%s\2 added to SPAM list.", spamtext);
@@ -595,16 +595,16 @@ void handle_spam(CSTR source, User *callerUser, ServiceCommandData *data) {
 								send_notice_to_user(data->agent->nick, callerUser, "Type for SPAM string \2%s\2 is already set to \2%d\2.", spam->text, type);
 							} else {
 								if (data->operMatch) {
-									LOG_SNOOP(data->agent->nick, "%s SPT %s -- by %s (%s@%s) [%d -> %d]", data->agent->shortNick, spam->text, callerUser->nick, callerUser->username, callerUser->host, spam->type, type);
-									log_services(data->agent->logID, "SPT %s -- by %s (%s@%s) [%d -> %d]", spam->text, callerUser->nick, callerUser->username, callerUser->host, spam->type, type);
-									send_SPAMOPS(data->agent->nick, "\2%s\2 changed type for SPAM string \2%s\2 from \2%d\2 to \2%d\2", source, spam->text, spam->type, type);
+									LOG_SNOOP(data->agent->nick, "%s SPT %s -- by %s (%s@%s) [%d -> %ld]", data->agent->shortNick, spam->text, callerUser->nick, callerUser->username, callerUser->host, spam->type, type);
+									log_services(data->agent->logID, "SPT %s -- by %s (%s@%s) [%d -> %ld]", spam->text, callerUser->nick, callerUser->username, callerUser->host, spam->type, type);
+									send_SPAMOPS(data->agent->nick, "\2%s\2 changed type for SPAM string \2%s\2 from \2%d\2 to \2%ld\2", source, spam->text, spam->type, type);
 								} else {
-									LOG_SNOOP(data->agent->nick, "%s SPT %s -- by %s (%s@%s) through %s [%d -> %d]", data->agent->shortNick, spam->text, callerUser->nick, callerUser->username, callerUser->host, data->operName, spam->type, type);
-									log_services(data->agent->logID, "SPT %s -- by %s (%s@%s) through [%d -> %d]", spam->text, callerUser->nick, callerUser->username, callerUser->host, data->operName, spam->type, type);
-									send_SPAMOPS(data->agent->nick, "\2%s\2 (through \2%s\2) changed type for SPAM string \2%s\2 from \2%d\2 to \2%d\2", source, data->operName, spam->text, spam->type, type);
+									LOG_SNOOP(data->agent->nick, "%s SPT %s -- by %s (%s@%s) through %s [%d -> %ld]", data->agent->shortNick, spam->text, callerUser->nick, callerUser->username, callerUser->host, data->operName, spam->type, type);
+									log_services(data->agent->logID, "SPT %s -- by %s (%s@%s) through %s [%d -> %ld]", spam->text, callerUser->nick, callerUser->username, callerUser->host, data->operName, spam->type, type);
+									send_SPAMOPS(data->agent->nick, "\2%s\2 (through \2%s\2) changed type for SPAM string \2%s\2 from \2%d\2 to \2%ld\2", source, data->operName, spam->text, spam->type, type);
 								}
 
-								send_notice_to_user(data->agent->nick, callerUser, "Type for SPAM string \2%s\2 is now set to \2%d\2.", spam->text, type);
+								send_notice_to_user(data->agent->nick, callerUser, "Type for SPAM string \2%s\2 is now set to \2%ld\2.", spam->text, type);
 
 								spam->type = type;
 

--- a/src/spam.c
+++ b/src/spam.c
@@ -592,7 +592,7 @@ void handle_spam(CSTR source, User *callerUser, ServiceCommandData *data) {
 									LOG_SNOOP(data->agent->nick, "%s *SPT %s -- by %s (%s@%s) [Already %d]", data->agent->shortNick, spam->text, callerUser->nick, callerUser->username, callerUser->host, spam->type);
 								else
 									LOG_SNOOP(data->agent->nick, "%s *SPT %s -- by %s (%s@%s) through %s [Already %d]", data->agent->shortNick, spam->text, callerUser->nick, callerUser->username, callerUser->host, data->operName, spam->type);
-								send_notice_to_user(data->agent->nick, callerUser, "Type for SPAM string \2%s\2 is already set to \2%d\2.", spam->text, type);
+								send_notice_to_user(data->agent->nick, callerUser, "Type for SPAM string \2%s\2 is already set to \2%d\2.", spam->text, spam->type);
 							} else {
 								if (data->operMatch) {
 									LOG_SNOOP(data->agent->nick, "%s SPT %s -- by %s (%s@%s) [%d -> %ld]", data->agent->shortNick, spam->text, callerUser->nick, callerUser->username, callerUser->host, spam->type, type);

--- a/src/spam.c
+++ b/src/spam.c
@@ -436,8 +436,8 @@ void handle_spam(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 			if (IS_NULL(spam)) {
 
-				long int	type;
-				char		*err;
+				int		type;
+				char	*err;
 
 				if (str_char_toupper(action[0]) == 'A') {
 
@@ -480,7 +480,7 @@ void handle_spam(CSTR source, User *callerUser, ServiceCommandData *data) {
 					return;
 				}
 
-				type = strtol(spamtype, &err, 10);
+				type = (int) strtol(spamtype, &err, 10);
 
 				if ((*err == '\0') && (type >= 0) && (type <= 5)) {
 
@@ -491,13 +491,13 @@ void handle_spam(CSTR source, User *callerUser, ServiceCommandData *data) {
 					send_SPAM(spamtext, type, reason);
 
 					if (data->operMatch) {
-						LOG_SNOOP(data->agent->nick, "%s +SP %s -- by %s (%s@%s) [Type: %ld - Reason: %s]", data->agent->shortNick, spamtext, callerUser->nick, callerUser->username, callerUser->host, type, reason);
-						log_services(data->agent->logID, "+SP %s -- by %s (%s@%s) [Type: %ld - Reason: %s]", spamtext, callerUser->nick, callerUser->username, callerUser->host, type, reason);
-						send_SPAMOPS(data->agent->nick, "\2%s\2 added a new SPAM [Text: \2%s\2] [Type: %ld] [Reason: %s]", source, spamtext, type, reason);
+						LOG_SNOOP(data->agent->nick, "%s +SP %s -- by %s (%s@%s) [Type: %d - Reason: %s]", data->agent->shortNick, spamtext, callerUser->nick, callerUser->username, callerUser->host, type, reason);
+						log_services(data->agent->logID, "+SP %s -- by %s (%s@%s) [Type: %d - Reason: %s]", spamtext, callerUser->nick, callerUser->username, callerUser->host, type, reason);
+						send_SPAMOPS(data->agent->nick, "\2%s\2 added a new SPAM [Text: \2%s\2] [Type: %d] [Reason: %s]", source, spamtext, type, reason);
 					} else {
-						LOG_SNOOP(data->agent->nick, "%s +SP %s -- by %s (%s@%s) through %s [Type: %ld - Reason: %s]", data->agent->shortNick, spamtext, callerUser->nick, callerUser->username, callerUser->host, data->operName, type, reason);
-						log_services(data->agent->logID, "+SP %s -- by %s (%s@%s) through %s [Type: %ld - Reason: %s]", spamtext, callerUser->nick, callerUser->username, callerUser->host, data->operName, type, reason);
-						send_SPAMOPS(data->agent->nick, "\2%s\2 (through \2%s\2) added a new SPAM [Text: \2%s\2] [Type: %ld] [Reason: %s]", source, data->operName, spamtext, type, reason);
+						LOG_SNOOP(data->agent->nick, "%s +SP %s -- by %s (%s@%s) through %s [Type: %d - Reason: %s]", data->agent->shortNick, spamtext, callerUser->nick, callerUser->username, callerUser->host, data->operName, type, reason);
+						log_services(data->agent->logID, "+SP %s -- by %s (%s@%s) through %s [Type: %d - Reason: %s]", spamtext, callerUser->nick, callerUser->username, callerUser->host, data->operName, type, reason);
+						send_SPAMOPS(data->agent->nick, "\2%s\2 (through \2%s\2) added a new SPAM [Text: \2%s\2] [Type: %d] [Reason: %s]", source, data->operName, spamtext, type, reason);
 					}
 
 					send_notice_to_user(data->agent->nick, callerUser, "\2%s\2 added to SPAM list.", spamtext);

--- a/src/spam.c
+++ b/src/spam.c
@@ -436,8 +436,9 @@ void handle_spam(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 			if (IS_NULL(spam)) {
 
-				int		type;
-				char	*err;
+				long int	stype;
+				int			type;
+				char		*err;
 
 				if (str_char_toupper(action[0]) == 'A') {
 
@@ -480,9 +481,11 @@ void handle_spam(CSTR source, User *callerUser, ServiceCommandData *data) {
 					return;
 				}
 
-				type = (int) strtol(spamtype, &err, 10);
+				stype = strtol(spamtype, &err, 10);
 
-				if ((*err == '\0') && (type >= 0) && (type <= 5)) {
+				if ((*err == '\0') && (stype >= 0) && (stype <= 5)) {
+
+					type = (int) stype;
 
 					spam = spam_create(spamtext, type, reason, data->operName);
 

--- a/src/statserv.c
+++ b/src/statserv.c
@@ -2582,7 +2582,7 @@ void statserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					send_notice_to_user(sourceNick, callerUser, "%05d) ADR\2 0x%08X\2 - NXT\2 0x%08X\2 - PRV\2 0x%08X\2 - KEY \2%s\2", idx, (unsigned long)cs, (unsigned long)cs->next, (unsigned long)cs->prev, str_get_valid_display_value(cs->name));
 			}
 
-			LOG_DEBUG_SNOOP("Command: DUMP STATSERV HASHTABLE %d %d %d -- by %s (%s@%s)", hashIdx, startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
+			LOG_DEBUG_SNOOP("Command: DUMP STATSERV HASHTABLE %ld %ld %ld -- by %s (%s@%s)", hashIdx, startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
 		}
 		else
 			needSyntax = TRUE;

--- a/src/statserv.c
+++ b/src/statserv.c
@@ -1436,7 +1436,13 @@ static void do_records(CSTR source, User *callerUser, ServiceCommandData *data) 
 
 	tm = *localtime(&records.maxservers_time);
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y %H:%M:%S %Z", &tm);
-	send_notice_to_user(s_StatServ, callerUser, "Current Servers: \2%lu\2 [Record: \2%lu\2 on %s]", nservers, records.maxservers, timebuf);
+#ifdef OS_64BIT
+#define NSERVER_SPEC "%lu"
+#else
+#define NSERVER_SPEC "%d"
+#endif
+	send_notice_to_user(s_StatServ, callerUser, "Current Servers: \2" NSERVER_SPEC "\2 [Record: \2%lu\2 on %s]", nservers, records.maxservers, timebuf);
+#undef NSERVER_SPEC
 
 	tm = *localtime(&records.maxconn_time);
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y", &tm);
@@ -1738,31 +1744,31 @@ static void do_chanstats(CSTR source, User *callerUser, ServiceCommandData *data
 
 		send_notice_to_user(s_StatServ, callerUser, " ");
 
-		send_notice_to_user(s_StatServ, callerUser, "Peak: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Peak: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totalpeak, cs->monthlypeak, cs->weeklypeak, cs->dailypeak);
-		send_notice_to_user(s_StatServ, callerUser, "Joins: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Joins: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totaljoins, cs->monthlyjoins, cs->weeklyjoins, cs->dailyjoins);
-		send_notice_to_user(s_StatServ, callerUser, "Parts: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Parts: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totalparts, cs->monthlyparts, cs->weeklyparts, cs->dailyparts);
-		send_notice_to_user(s_StatServ, callerUser, "Kicks: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Kicks: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totalkicks, cs->monthlykicks, cs->weeklykicks, cs->dailykicks);
-		send_notice_to_user(s_StatServ, callerUser, "Bans: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Bans: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totalbans, cs->monthlybans, cs->weeklybans, cs->dailybans);
-		send_notice_to_user(s_StatServ, callerUser, "Oppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Oppings: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totaloppings, cs->monthlyoppings, cs->weeklyoppings, cs->dailyoppings);
-		send_notice_to_user(s_StatServ, callerUser, "Deoppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Deoppings: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totaldeoppings, cs->monthlydeoppings, cs->weeklydeoppings, cs->dailydeoppings);
-		send_notice_to_user(s_StatServ, callerUser, "Halfoppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Halfoppings: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totalhalfoppings, cs->monthlyhalfoppings, cs->weeklyhalfoppings, cs->dailyhalfoppings);
-		send_notice_to_user(s_StatServ, callerUser, "Dehalfoppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Dehalfoppings: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totaldehalfoppings, cs->monthlydehalfoppings, cs->weeklydehalfoppings, cs->dailydehalfoppings);
-		send_notice_to_user(s_StatServ, callerUser, "Voicings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Voicings: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totalvoicings, cs->monthlyvoicings, cs->weeklyvoicings, cs->dailyvoicings);
-		send_notice_to_user(s_StatServ, callerUser, "Devoicings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Devoicings: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totaldevoicings, cs->monthlydevoicings, cs->weeklydevoicings, cs->dailydevoicings);
-		send_notice_to_user(s_StatServ, callerUser, "Topics: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
+		send_notice_to_user(s_StatServ, callerUser, "Topics: T: \2%" PRIu64 "\2, M: \2%" PRIu64 "\2, W: \2%" PRIu64 "\2, D: \2%" PRIu64 "\2",
 			cs->totaltopics, cs->monthlytopics, cs->weeklytopics, cs->dailytopics);
-		send_notice_to_user(s_StatServ, callerUser, "Modes: T: \2%lu\2 (\2%lu\2+, \2%lu\2-), M: \2%lu\2 (\2%lu\2+, \2%lu\2-), W: \2%lu\2 (\2%lu\2+, \2%lu\2-), D: \2%lu\2 (\2%lu\2+, \2%lu\2-)",
+		send_notice_to_user(s_StatServ, callerUser, "Modes: T: \2%" PRIu64 "\2 (\2%" PRIu64 "\2+, \2%" PRIu64 "\2-), M: \2%" PRIu64 "\2 (\2%" PRIu64 "\2+, \2%" PRIu64 "\2-), W: \2%" PRIu64 "\2 (\2%" PRIu64 "\2+, \2%" PRIu64 "\2-), D: \2%" PRIu64 "\2 (\2%" PRIu64 "\2+, \2%" PRIu64 "\2-)",
 			(cs->totaladdcmodes + cs->totaldelcmodes), cs->totaladdcmodes, cs->totaldelcmodes, (cs->monthlyaddcmodes + cs->monthlydelcmodes), cs->monthlyaddcmodes, cs->monthlydelcmodes, (cs->weeklyaddcmodes + cs->weeklydelcmodes), cs->weeklyaddcmodes, cs->weeklydelcmodes, (cs->dailyaddcmodes + cs->dailydelcmodes), cs->dailyaddcmodes, cs->dailydelcmodes);
 		send_notice_to_user(s_StatServ, callerUser, " ");
 		send_notice_to_user(s_StatServ, callerUser, "\2*** Fine delle Statistiche ***\2");

--- a/src/statserv.c
+++ b/src/statserv.c
@@ -1436,7 +1436,7 @@ static void do_records(CSTR source, User *callerUser, ServiceCommandData *data) 
 
 	tm = *localtime(&records.maxservers_time);
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y %H:%M:%S %Z", &tm);
-	send_notice_to_user(s_StatServ, callerUser, "Current Servers: \2l%lu\2 [Record: \2%lu\2 on %s]", nservers, records.maxservers, timebuf);
+	send_notice_to_user(s_StatServ, callerUser, "Current Servers: \2%lu\2 [Record: \2%lu\2 on %s]", nservers, records.maxservers, timebuf);
 
 	tm = *localtime(&records.maxconn_time);
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y", &tm);

--- a/src/statserv.c
+++ b/src/statserv.c
@@ -1207,7 +1207,7 @@ static void do_map(CSTR source, User *callerUser, ServiceCommandData *data) {
 		int count = 0;
 
 		send_notice_to_user(s_StatServ, callerUser, "\2Server Listing:\2");
-		send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+		send_notice_to_user(s_StatServ, callerUser, " ");
 
 		TRACE_MAIN();
 
@@ -1221,7 +1221,7 @@ static void do_map(CSTR source, User *callerUser, ServiceCommandData *data) {
 		}
 
 		TRACE_MAIN();
-		send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+		send_notice_to_user(s_StatServ, callerUser, " ");
 		send_notice_to_user(s_StatServ, callerUser, "*** \2End of List\2 ***");
 	}
 	else if (!CheckOperAccess(data->userLevel, CMDLEVEL_SOP))
@@ -1376,27 +1376,27 @@ static void do_netstats(CSTR source, User *callerUser, ServiceCommandData *data)
 	TRACE_MAIN_FCLT(FACILITY_STATSERV_HANDLE_NETSTATS);
 
 	send_notice_to_user(s_StatServ, callerUser, "\2*** Global Network Statistics ***\2");
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+	send_notice_to_user(s_StatServ, callerUser, " ");
 
-	send_notice_to_user(s_StatServ, callerUser, "Nick Changes: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.nicks, monthly.nicks, weekly.nicks, daily.nicks);
-	send_notice_to_user(s_StatServ, callerUser, "Kills: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.kills, monthly.kills, weekly.kills, daily.kills);
-	send_notice_to_user(s_StatServ, callerUser, "Service Kills: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.skills, monthly.skills, weekly.skills, daily.skills);
-	send_notice_to_user(s_StatServ, callerUser, "Channel Joins: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.joins, monthly.joins, weekly.joins, daily.joins);
-	send_notice_to_user(s_StatServ, callerUser, "Channel Parts: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.parts, monthly.parts, weekly.parts, daily.parts);
-	send_notice_to_user(s_StatServ, callerUser, "Quits: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.quits, monthly.quits, weekly.quits, daily.quits);
-	send_notice_to_user(s_StatServ, callerUser, "Kicks: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.kicks, monthly.kicks, weekly.kicks, daily.kicks);
-	send_notice_to_user(s_StatServ, callerUser, "Bans: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.bans, monthly.bans, weekly.bans, daily.bans);
-	send_notice_to_user(s_StatServ, callerUser, "Channel Modes: T: \2%ld\2 (\2%d\2+, \2%d\2-), M: \2%ld\2 (\2%d\2+, \2%d\2-), W: \2%ld\2 (\2%d\2+, \2%d\2-), D:\2%ld\2 (\2%d\2+, \2%d\2-)", (total.addcmodes + total.delcmodes), total.addcmodes, total.delcmodes, (monthly.addcmodes + monthly.delcmodes), monthly.addcmodes, monthly.delcmodes, (weekly.addcmodes + weekly.delcmodes), weekly.addcmodes, weekly.delcmodes, (daily.addcmodes + daily.delcmodes), daily.addcmodes, daily.delcmodes);
-	send_notice_to_user(s_StatServ, callerUser, "Connections: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.connections, monthly.connections, weekly.connections, daily.connections);
-	send_notice_to_user(s_StatServ, callerUser, "Oppings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.oppings, monthly.oppings, weekly.oppings, daily.oppings);
-	send_notice_to_user(s_StatServ, callerUser, "Deoppings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.deoppings, monthly.deoppings, weekly.deoppings, daily.deoppings);
-	send_notice_to_user(s_StatServ, callerUser, "Halfoppings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.halfoppings, monthly.halfoppings, weekly.halfoppings, daily.halfoppings);
-	send_notice_to_user(s_StatServ, callerUser, "Dehalfoppings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.dehalfoppings, monthly.dehalfoppings, weekly.dehalfoppings, daily.dehalfoppings);
-	send_notice_to_user(s_StatServ, callerUser, "Voicings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.voicings, monthly.voicings, weekly.voicings, daily.voicings);
-	send_notice_to_user(s_StatServ, callerUser, "Devoicings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.devoicings, monthly.devoicings, weekly.devoicings, daily.devoicings);
-	send_notice_to_user(s_StatServ, callerUser, "Topics: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D:\2%ld\2", total.topics, monthly.topics, weekly.topics, daily.topics);
+	send_notice_to_user(s_StatServ, callerUser, "Nick Changes: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.nicks, monthly.nicks, weekly.nicks, daily.nicks);
+	send_notice_to_user(s_StatServ, callerUser, "Kills: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.kills, monthly.kills, weekly.kills, daily.kills);
+	send_notice_to_user(s_StatServ, callerUser, "Service Kills: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.skills, monthly.skills, weekly.skills, daily.skills);
+	send_notice_to_user(s_StatServ, callerUser, "Channel Joins: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.joins, monthly.joins, weekly.joins, daily.joins);
+	send_notice_to_user(s_StatServ, callerUser, "Channel Parts: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.parts, monthly.parts, weekly.parts, daily.parts);
+	send_notice_to_user(s_StatServ, callerUser, "Quits: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.quits, monthly.quits, weekly.quits, daily.quits);
+	send_notice_to_user(s_StatServ, callerUser, "Kicks: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.kicks, monthly.kicks, weekly.kicks, daily.kicks);
+	send_notice_to_user(s_StatServ, callerUser, "Bans: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.bans, monthly.bans, weekly.bans, daily.bans);
+	send_notice_to_user(s_StatServ, callerUser, "Channel Modes: T: \2%lu\2 (\2%lu\2+, \2%lu\2-), M: \2%lu\2 (\2%lu\2+, \2%lu\2-), W: \2%lu\2 (\2%lu\2+, \2%lu\2-), D:\2%lu\2 (\2%lu\2+, \2%lu\2-)", (total.addcmodes + total.delcmodes), total.addcmodes, total.delcmodes, (monthly.addcmodes + monthly.delcmodes), monthly.addcmodes, monthly.delcmodes, (weekly.addcmodes + weekly.delcmodes), weekly.addcmodes, weekly.delcmodes, (daily.addcmodes + daily.delcmodes), daily.addcmodes, daily.delcmodes);
+	send_notice_to_user(s_StatServ, callerUser, "Connections: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.connections, monthly.connections, weekly.connections, daily.connections);
+	send_notice_to_user(s_StatServ, callerUser, "Oppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.oppings, monthly.oppings, weekly.oppings, daily.oppings);
+	send_notice_to_user(s_StatServ, callerUser, "Deoppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.deoppings, monthly.deoppings, weekly.deoppings, daily.deoppings);
+	send_notice_to_user(s_StatServ, callerUser, "Halfoppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.halfoppings, monthly.halfoppings, weekly.halfoppings, daily.halfoppings);
+	send_notice_to_user(s_StatServ, callerUser, "Dehalfoppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.dehalfoppings, monthly.dehalfoppings, weekly.dehalfoppings, daily.dehalfoppings);
+	send_notice_to_user(s_StatServ, callerUser, "Voicings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.voicings, monthly.voicings, weekly.voicings, daily.voicings);
+	send_notice_to_user(s_StatServ, callerUser, "Devoicings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.devoicings, monthly.devoicings, weekly.devoicings, daily.devoicings);
+	send_notice_to_user(s_StatServ, callerUser, "Topics: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D:\2%lu\2", total.topics, monthly.topics, weekly.topics, daily.topics);
 
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+	send_notice_to_user(s_StatServ, callerUser, " ");
 	send_notice_to_user(s_StatServ, callerUser, "*** \2End of Net Stats\2 ***");
 }
 
@@ -1420,35 +1420,35 @@ static void do_records(CSTR source, User *callerUser, ServiceCommandData *data) 
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y %H:%M:%S %Z", &tm);
 	send_notice_to_user(s_StatServ, callerUser, "Current time: %s", timebuf);
 
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+	send_notice_to_user(s_StatServ, callerUser, " ");
 
 	tm = *localtime(&records.maxusers_time);
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y %H:%M:%S %Z", &tm);
-	send_notice_to_user(s_StatServ, callerUser, "Current Users: \2%u\2 [Record: \2%u\2 on %s]", user_online_user_count, records.maxusers, timebuf);
+	send_notice_to_user(s_StatServ, callerUser, "Current Users: \2%u\2 [Record: \2%lu\2 on %s]", user_online_user_count, records.maxusers, timebuf);
 
 	tm = *localtime(&records.maxchannels_time);
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y %H:%M:%S %Z", &tm);
-	send_notice_to_user(s_StatServ, callerUser, "Current Chans: \2%u\2 [Record: \2%u\2 on %s]", stats_open_channels_count, records.maxchannels, timebuf);
+	send_notice_to_user(s_StatServ, callerUser, "Current Chans: \2%u\2 [Record: \2%lu\2 on %s]", stats_open_channels_count, records.maxchannels, timebuf);
 
 	tm = *localtime(&records.maxopers_time);
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y %H:%M:%S %Z", &tm);
-	send_notice_to_user(s_StatServ, callerUser, "Current Opers: \2%u\2 [Record: \2%u\2 on %s]", user_online_operator_count, records.maxopers, timebuf);
+	send_notice_to_user(s_StatServ, callerUser, "Current Opers: \2%u\2 [Record: \2%lu\2 on %s]", user_online_operator_count, records.maxopers, timebuf);
 
 	tm = *localtime(&records.maxservers_time);
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y %H:%M:%S %Z", &tm);
-	send_notice_to_user(s_StatServ, callerUser, "Current Servers: \2%u\2 [Record: \2%u\2 on %s]", nservers, records.maxservers, timebuf);
+	send_notice_to_user(s_StatServ, callerUser, "Current Servers: \2l%lu\2 [Record: \2%lu\2 on %s]", nservers, records.maxservers, timebuf);
 
 	tm = *localtime(&records.maxconn_time);
 	strftime(timebuf, sizeof(timebuf), "%a %d/%m/%Y", &tm);
-	send_notice_to_user(s_StatServ, callerUser, "Current Connections: \2%u\2 [Record: \2%u\2 on %s]", daily.connections, records.maxconn, timebuf);
+	send_notice_to_user(s_StatServ, callerUser, "Current Connections: \2%lu\2 [Record: \2%lu\2 on %s]", daily.connections, records.maxconn, timebuf);
 
 	TRACE_MAIN();
 
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+	send_notice_to_user(s_StatServ, callerUser, " ");
 	send_notice_to_user(s_StatServ, callerUser, "\2Average Statistics\2:");
 	send_notice_to_user(s_StatServ, callerUser, "Average Users/Chans: %.2f/%.2f", uavg, cavg);
 	send_notice_to_user(s_StatServ, callerUser, "Average Servers/Opers: %.2f/%.2f", savg, oavg);
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+	send_notice_to_user(s_StatServ, callerUser, " ");
 
 	tm = *localtime(&NOW);
 	strftime(timebuf, sizeof(timebuf), "%d/%m/%Y", &tm);
@@ -1530,7 +1530,7 @@ static void do_listreg(CSTR source, User *callerUser, ServiceCommandData *data) 
 				if (line < start_line)
 					continue;
 
-				send_notice_to_user(s_StatServ, callerUser, "%d) %s", line, cs->name);
+				send_notice_to_user(s_StatServ, callerUser, "%lu) %s", line, cs->name);
 				++count;
 
 				if (line >= end_line)
@@ -1540,7 +1540,7 @@ static void do_listreg(CSTR source, User *callerUser, ServiceCommandData *data) 
 	}
 
 	TRACE_MAIN();
-	send_notice_to_user(s_StatServ, callerUser, "\2*** End of Search. Channel%s found: %d ***\2", count == 1 ? "" : "s", count);
+	send_notice_to_user(s_StatServ, callerUser, "\2*** End of Search. Channel%s found: %lu ***\2", count == 1 ? "" : "s", count);
 }
 
 /*********************************************************/
@@ -1562,7 +1562,7 @@ static void do_delete(CSTR source, User *callerUser, ServiceCommandData *data) {
 	if (IS_NULL(channel = strtok(NULL, " "))) {
 
 		send_notice_to_user(s_StatServ, callerUser, "Syntax: \2DELETE\2 #channel");
-		send_notice_to_user(s_StatServ, callerUser, "Type \2/st OHELP %s\2 for more information.");
+		send_notice_to_user(s_StatServ, callerUser, "Type \2/st OHELP DELETE\2 for more information.");
 		return;
 	}
 
@@ -1639,7 +1639,7 @@ static void do_server(CSTR source, User *callerUser, ServiceCommandData *data) {
 	TRACE_MAIN();
 
 	send_notice_to_user(s_StatServ, callerUser, "\2Server Information\2 for \2%s\2:", ss->name);
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+	send_notice_to_user(s_StatServ, callerUser, " ");
 
 	tm = *localtime(&NOW);
 	strftime(timebuf, sizeof(timebuf), "%a %m/%d/%Y %H:%M:%S %Z", &tm);
@@ -1648,7 +1648,7 @@ static void do_server(CSTR source, User *callerUser, ServiceCommandData *data) {
 	tm = *localtime(&ss->time_added);
 	strftime(timebuf, sizeof(timebuf), "%a %m/%d/%Y %H:%M:%S %Z", &tm);
 	send_notice_to_user(s_StatServ, callerUser, "Stats From: %s", timebuf);
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+	send_notice_to_user(s_StatServ, callerUser, " ");
 
 	if (FlagUnset(ss->flags, STATS_SERVER_ONLINE)) {
 
@@ -1663,7 +1663,7 @@ static void do_server(CSTR source, User *callerUser, ServiceCommandData *data) {
 		send_notice_to_user(s_StatServ, callerUser, "Server is \2Online\2. [Connected on %s]", timebuf);
 	}
 
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+	send_notice_to_user(s_StatServ, callerUser, " ");
 
 	tm = *localtime(&ss->maxclients_time);
 	strftime(timebuf, sizeof(timebuf), "%a %m/%d/%Y %H:%M:%S %Z", &tm);
@@ -1678,13 +1678,13 @@ static void do_server(CSTR source, User *callerUser, ServiceCommandData *data) {
 	send_notice_to_user(s_StatServ, callerUser, "Average Users/Opers: \2%.2f\2/\2%.2f\2",
 		ss->users_average, ss->opers_average);
 
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
-	send_notice_to_user(s_StatServ, callerUser, "Server Hits: \2%d\2", ss->hits);
-	send_notice_to_user(s_StatServ, callerUser, "Server Messages: \2%d\2", ss->msgs);
+	send_notice_to_user(s_StatServ, callerUser, " ");
+	send_notice_to_user(s_StatServ, callerUser, "Server Hits: \2%lu\2", ss->hits);
+	send_notice_to_user(s_StatServ, callerUser, "Server Messages: \2%lu\2", ss->msgs);
 	send_notice_to_user(s_StatServ, callerUser, "Oper/Server Kills: \2%d\2/\2%d\2", ss->operkills, ss->servkills);
 	send_notice_to_user(s_StatServ, callerUser, "Splits: T: \2%d\2, M: \2%d\2, W: \2%d\2, D: \2%d\2", ss->totalsplits, ss->monthlysplits, ss->weeklysplits, ss->dailysplits);
 
-	send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+	send_notice_to_user(s_StatServ, callerUser, " ");
 	send_notice_to_user(s_StatServ, callerUser, "\2*** End of Server Information ***\2");
 }
 
@@ -1724,7 +1724,7 @@ static void do_chanstats(CSTR source, User *callerUser, ServiceCommandData *data
 
 		TRACE_MAIN();
 		send_notice_to_user(s_StatServ, callerUser, "Statistiche di \2%s\2:", cs->name);
-		send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+		send_notice_to_user(s_StatServ, callerUser, " ");
 
 		send_notice_to_user(s_StatServ, callerUser, "Data di inizio: %s", timebuf);
 
@@ -1736,35 +1736,35 @@ static void do_chanstats(CSTR source, User *callerUser, ServiceCommandData *data
 		strftime(timebuf, sizeof(timebuf), "%d/%m/%Y %H:%M:%S", &tm);
 		send_notice_to_user(s_StatServ, callerUser, "Ora corrente: %s", timebuf);
 
-		send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+		send_notice_to_user(s_StatServ, callerUser, " ");
 
-		send_notice_to_user(s_StatServ, callerUser, "Peak: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Peak: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totalpeak, cs->monthlypeak, cs->weeklypeak, cs->dailypeak);
-		send_notice_to_user(s_StatServ, callerUser, "Joins: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Joins: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totaljoins, cs->monthlyjoins, cs->weeklyjoins, cs->dailyjoins);
-		send_notice_to_user(s_StatServ, callerUser, "Parts: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Parts: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totalparts, cs->monthlyparts, cs->weeklyparts, cs->dailyparts);
-		send_notice_to_user(s_StatServ, callerUser, "Kicks: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Kicks: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totalkicks, cs->monthlykicks, cs->weeklykicks, cs->dailykicks);
-		send_notice_to_user(s_StatServ, callerUser, "Bans: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Bans: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totalbans, cs->monthlybans, cs->weeklybans, cs->dailybans);
-		send_notice_to_user(s_StatServ, callerUser, "Oppings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Oppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totaloppings, cs->monthlyoppings, cs->weeklyoppings, cs->dailyoppings);
-		send_notice_to_user(s_StatServ, callerUser, "Deoppings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Deoppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totaldeoppings, cs->monthlydeoppings, cs->weeklydeoppings, cs->dailydeoppings);
-		send_notice_to_user(s_StatServ, callerUser, "Halfoppings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Halfoppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totalhalfoppings, cs->monthlyhalfoppings, cs->weeklyhalfoppings, cs->dailyhalfoppings);
-		send_notice_to_user(s_StatServ, callerUser, "Dehalfoppings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Dehalfoppings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totaldehalfoppings, cs->monthlydehalfoppings, cs->weeklydehalfoppings, cs->dailydehalfoppings);
-		send_notice_to_user(s_StatServ, callerUser, "Voicings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Voicings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totalvoicings, cs->monthlyvoicings, cs->weeklyvoicings, cs->dailyvoicings);
-		send_notice_to_user(s_StatServ, callerUser, "Devoicings: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Devoicings: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totaldevoicings, cs->monthlydevoicings, cs->weeklydevoicings, cs->dailydevoicings);
-		send_notice_to_user(s_StatServ, callerUser, "Topics: T: \2%ld\2, M: \2%ld\2, W: \2%ld\2, D: \2%ld\2",
+		send_notice_to_user(s_StatServ, callerUser, "Topics: T: \2%lu\2, M: \2%lu\2, W: \2%lu\2, D: \2%lu\2",
 			cs->totaltopics, cs->monthlytopics, cs->weeklytopics, cs->dailytopics);
-		send_notice_to_user(s_StatServ, callerUser, "Modes: T: \2%ld\2 (\2%ld\2+, \2%ld\2-), M: \2%ld\2 (\2%ld\2+, \2%ld\2-), W: \2%ld\2 (\2%ld\2+, \2%ld\2-), D: \2%ld\2 (\2%ld\2+, \2%ld\2-)",
+		send_notice_to_user(s_StatServ, callerUser, "Modes: T: \2%lu\2 (\2%lu\2+, \2%lu\2-), M: \2%lu\2 (\2%lu\2+, \2%lu\2-), W: \2%lu\2 (\2%lu\2+, \2%lu\2-), D: \2%lu\2 (\2%lu\2+, \2%lu\2-)",
 			(cs->totaladdcmodes + cs->totaldelcmodes), cs->totaladdcmodes, cs->totaldelcmodes, (cs->monthlyaddcmodes + cs->monthlydelcmodes), cs->monthlyaddcmodes, cs->monthlydelcmodes, (cs->weeklyaddcmodes + cs->weeklydelcmodes), cs->weeklyaddcmodes, cs->weeklydelcmodes, (cs->dailyaddcmodes + cs->dailydelcmodes), cs->dailyaddcmodes, cs->dailydelcmodes);
-		send_notice_to_user(s_StatServ, callerUser, s_SPACE);
+		send_notice_to_user(s_StatServ, callerUser, " ");
 		send_notice_to_user(s_StatServ, callerUser, "\2*** Fine delle Statistiche ***\2");
 	}
 	else
@@ -2519,11 +2519,11 @@ void statserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				send_notice_to_user(sourceNick, callerUser, "DUMP: Stats record for \2%s\2:", chan_name);
 
-				send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",						(unsigned long)cs, sizeof(ChannelStats) + str_len(cs->name) + 1);
-				send_notice_to_user(sourceNick, callerUser, "Name: 0x%08X \2[\2%s\2]\2",						(unsigned long)cs->name, str_get_valid_display_value(cs->name));
-				send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %d",							cs->time_added);
-				send_notice_to_user(sourceNick, callerUser, "Last Change C-time: %d",							cs->last_change);
-				send_notice_to_user(sourceNick, callerUser, "Next / previous record: 0x%08X / 0x%08X",			(unsigned long)cs->next, (unsigned long)cs->prev);
+				send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			cs, sizeof(ChannelStats) + str_len(cs->name) + 1);
+				send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			cs->name, str_get_valid_display_value(cs->name));
+				send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",			cs->time_added);
+				send_notice_to_user(sourceNick, callerUser, "Last Change C-time: %ld",			cs->last_change);
+				send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	cs->next, cs->prev);
 
 				LOG_DEBUG_SNOOP("Command: DUMP STATSERV CHAN %s -- by %s (%s@%s)", chan_name, callerUser->nick, callerUser->username, callerUser->host);
 			}
@@ -2579,7 +2579,7 @@ void statserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			for (idx = 0, cs = hashtable_chanstats[hashIdx]; IS_NOT_NULL(cs) && (idx <= endIdx); ++idx, cs = cs->next) {
 
 				if (idx >= startIdx)
-					send_notice_to_user(sourceNick, callerUser, "%05d) ADR\2 0x%08X\2 - NXT\2 0x%08X\2 - PRV\2 0x%08X\2 - KEY \2%s\2", idx, (unsigned long)cs, (unsigned long)cs->next, (unsigned long)cs->prev, str_get_valid_display_value(cs->name));
+					send_notice_to_user(sourceNick, callerUser, "%05ld) ADR\2 %p\2 - NXT\2 %p\2 - PRV\2 %p\2 - KEY \2%s\2", idx, cs, cs->next, cs->prev, str_get_valid_display_value(cs->name));
 			}
 
 			LOG_DEBUG_SNOOP("Command: DUMP STATSERV HASHTABLE %ld %ld %ld -- by %s (%s@%s)", hashIdx, startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
@@ -2594,11 +2594,11 @@ void statserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 		MemoryPoolStats pstats;
 
 		mempool_stats(stats_chan_mempool, &pstats);
-		send_notice_to_user(sourceNick, callerUser, "DUMP: StatServ chanstat memory pool - Address 0x%08X, ID: %d",	(unsigned long)stats_chan_mempool, pstats.id);
-		send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %d B / %d B",							pstats.memory_allocated, pstats.memory_free);
-		send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %d / %d",								pstats.items_allocated, pstats.items_free);
-		send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %d / %d",						pstats.items_per_block, pstats.block_count);
-		//send_notice_to_user(sourceNick, callerUser, "Avarage use: %.2f%%",										pstats.block_avg_usage);
+		send_notice_to_user(sourceNick, callerUser, "DUMP: StatServ chanstat memory pool - Address %p, ID: %u",	stats_chan_mempool, pstats.id);
+		send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",					pstats.memory_allocated, pstats.memory_free);
+		send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",						pstats.items_allocated, pstats.items_free);
+		send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",					pstats.items_per_block, pstats.block_count);
+		//send_notice_to_user(sourceNick, callerUser, "Avarage use: %.2f%%",									pstats.block_avg_usage);
 
 		LOG_DEBUG_SNOOP("Command: DUMP STATSERV POOLSTAT -- by %s (%s@%s)", callerUser->nick, callerUser->username, callerUser->host);
 	}
@@ -2638,7 +2638,7 @@ unsigned long statserv_mem_report(CSTR sourceNick, const User *callerUser) {
 
 	/* Global stats */
 	mem_total = (sizeof(GlobalStats) * 4);
-	send_notice_to_user(sourceNick, callerUser, "Global stats: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", 4, mem_total / 1024, mem_total);
+	send_notice_to_user(sourceNick, callerUser, "Global stats: \2%d\2 -> \2%lu\2 KB (\2%lu\2 B)", 4, mem_total / 1024, mem_total);
 
 
 	/* Channel stats */
@@ -2654,7 +2654,7 @@ unsigned long statserv_mem_report(CSTR sourceNick, const User *callerUser) {
 	mem += (sizeof(ChannelStats) * count);
 
 	TRACE();
-	send_notice_to_user(sourceNick, callerUser, "Channel stats records: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Channel stats records: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	mem_total += mem;
 
 
@@ -2669,7 +2669,7 @@ unsigned long statserv_mem_report(CSTR sourceNick, const User *callerUser) {
 	}
 
 	TRACE();
-	send_notice_to_user(sourceNick, callerUser, "Server records: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Server records: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	mem_total += mem;
 
 	return mem_total;

--- a/src/statserv.c
+++ b/src/statserv.c
@@ -2519,11 +2519,11 @@ void statserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 				send_notice_to_user(sourceNick, callerUser, "DUMP: Stats record for \2%s\2:", chan_name);
 
-				send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",			cs, sizeof(ChannelStats) + str_len(cs->name) + 1);
-				send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			cs->name, str_get_valid_display_value(cs->name));
+				send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",			(void *)cs, sizeof(ChannelStats) + str_len(cs->name) + 1);
+				send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",			(void *)cs->name, str_get_valid_display_value(cs->name));
 				send_notice_to_user(sourceNick, callerUser, "Time Added C-time: %ld",			cs->time_added);
 				send_notice_to_user(sourceNick, callerUser, "Last Change C-time: %ld",			cs->last_change);
-				send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	cs->next, cs->prev);
+				send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",	(void *)cs->next, (void *)cs->prev);
 
 				LOG_DEBUG_SNOOP("Command: DUMP STATSERV CHAN %s -- by %s (%s@%s)", chan_name, callerUser->nick, callerUser->username, callerUser->host);
 			}
@@ -2579,7 +2579,7 @@ void statserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			for (idx = 0, cs = hashtable_chanstats[hashIdx]; IS_NOT_NULL(cs) && (idx <= endIdx); ++idx, cs = cs->next) {
 
 				if (idx >= startIdx)
-					send_notice_to_user(sourceNick, callerUser, "%05ld) ADR\2 %p\2 - NXT\2 %p\2 - PRV\2 %p\2 - KEY \2%s\2", idx, cs, cs->next, cs->prev, str_get_valid_display_value(cs->name));
+					send_notice_to_user(sourceNick, callerUser, "%05ld) ADR\2 %p\2 - NXT\2 %p\2 - PRV\2 %p\2 - KEY \2%s\2", idx, (void *)cs, (void *)cs->next, (void *)cs->prev, str_get_valid_display_value(cs->name));
 			}
 
 			LOG_DEBUG_SNOOP("Command: DUMP STATSERV HASHTABLE %ld %ld %ld -- by %s (%s@%s)", hashIdx, startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
@@ -2594,7 +2594,7 @@ void statserv_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 		MemoryPoolStats pstats;
 
 		mempool_stats(stats_chan_mempool, &pstats);
-		send_notice_to_user(sourceNick, callerUser, "DUMP: StatServ chanstat memory pool - Address %p, ID: %u",	stats_chan_mempool, pstats.id);
+		send_notice_to_user(sourceNick, callerUser, "DUMP: StatServ chanstat memory pool - Address %p, ID: %u",	(void *)stats_chan_mempool, pstats.id);
 		send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",					pstats.memory_allocated, pstats.memory_free);
 		send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",						pstats.items_allocated, pstats.items_free);
 		send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",					pstats.items_per_block, pstats.block_count);

--- a/src/storage.c
+++ b/src/storage.c
@@ -88,7 +88,7 @@ typedef struct _RecordDescriptor {
 
 #define STORAGE_COMPATIBILITY_VERSION		7
 
-#define STORAGE_RECORD_SIGNATURE_V1			93
+#define STORAGE_RECORD_SIGNATURE_V1			93U
 #define STORAGE_CURRENT_RECORD_SIGNATURE	STORAGE_RECORD_SIGNATURE_V1
 
 // RecordDescriptor.flags
@@ -737,11 +737,7 @@ const char *stg_result_to_string(STG_RESULT result) {
 	return (CSTR) buffer;
 }
 
-
 void stg_report_sysinfo(CSTR sourceNick, const char *caller) {
 
 	send_notice_to_nick(sourceNick, caller, "Storage info: Version \2%d\2 - Compatibility version \2%d\2 - Signature \2%s\2 - Record signature\2 0x%04X\2", STORAGE_CURRENT_VERSION, STORAGE_COMPATIBILITY_VERSION, STORAGE_SIGNATURE, STORAGE_CURRENT_RECORD_SIGNATURE);
 }
-
-
-

--- a/src/sxline.c
+++ b/src/sxline.c
@@ -272,7 +272,7 @@ void sxline_burst_send(void) {
 
 	while (IS_NOT_NULL(aSXLine)) {
 
-		send_cmd("SGLINE %lu :%s:%s", str_len(aSXLine->name), aSXLine->name, aSXLine->info.reason);
+		send_cmd("SGLINE %zu :%s:%s", str_len(aSXLine->name), aSXLine->name, aSXLine->info.reason);
 		aSXLine = aSXLine->next;
 	}
 }
@@ -614,7 +614,7 @@ void handle_sxline(CSTR source, User *callerUser, ServiceCommandData *data) {
 		if (isQLine)
 			send_cmd("SQLINE %s :%s", name, reason);
 		else
-			send_cmd("SGLINE %lu :%s:%s", str_len(name), name, reason);
+			send_cmd("SGLINE %zu :%s:%s", str_len(name), name, reason);
 
 		TRACE_MAIN();
 
@@ -833,7 +833,7 @@ void sxline_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	lineIdx, (void *)aSXLine, sizeof(SXLine));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",	lineIdx, (void *)aSXLine, sizeof(SXLine));
 		send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",		(void *)aSXLine->name, str_get_valid_display_value(aSXLine->name));
 		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		(void *)aSXLine->info.creator.name, str_get_valid_display_value(aSXLine->info.creator.name));
 		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)aSXLine->info.reason, str_get_valid_display_value(aSXLine->info.reason));

--- a/src/sxline.c
+++ b/src/sxline.c
@@ -272,7 +272,7 @@ void sxline_burst_send(void) {
 
 	while (IS_NOT_NULL(aSXLine)) {
 
-		send_cmd("SGLINE %d :%s:%s", str_len(aSXLine->name), aSXLine->name, aSXLine->info.reason);
+		send_cmd("SGLINE %lu :%s:%s", str_len(aSXLine->name), aSXLine->name, aSXLine->info.reason);
 		aSXLine = aSXLine->next;
 	}
 }
@@ -568,7 +568,7 @@ void handle_sxline(CSTR source, User *callerUser, ServiceCommandData *data) {
 			}
 			else {
 
-				send_globops(s_OperServ, "\2%s\2 (through \2%s\2) tried to S%c:Line \2%.3f%s\2 of the network! (Limit: %.3f%s)", source, data->commandName[1], data->operName, percent, "%", CONF_AKILL_PERCENT, "%");
+				send_globops(s_OperServ, "\2%s\2 (through \2%s\2) tried to S%c:Line \2%.3f%s\2 of the network! (Limit: %.3f%s)", source, data->operName, data->commandName[1], percent, "%", CONF_AKILL_PERCENT, "%");
 
 				LOG_SNOOP(s_OperServ, "OS +S%c* %s -- by %s (%s@%s) through %s [%.3f%s > %.3f%s]", data->commandName[1], name, callerUser->nick, callerUser->username, callerUser->host, data->operName, percent, "%", CONF_AKILL_PERCENT, "%");
 				log_services(LOG_SERVICES_OPERSERV, "+S%c* %s -- by %s (%s@%s) through %s [%.3f%s > %.3f%s]", data->commandName[1], name, callerUser->nick, callerUser->username, callerUser->host, data->operName, percent, "%", CONF_AKILL_PERCENT, "%");
@@ -614,7 +614,7 @@ void handle_sxline(CSTR source, User *callerUser, ServiceCommandData *data) {
 		if (isQLine)
 			send_cmd("SQLINE %s :%s", name, reason);
 		else
-			send_cmd("SGLINE %d :%s:%s", str_len(name), name, reason);
+			send_cmd("SGLINE %lu :%s:%s", str_len(name), name, reason);
 
 		TRACE_MAIN();
 

--- a/src/sxline.c
+++ b/src/sxline.c
@@ -7,7 +7,7 @@
 * details.
 *
 * sxline.c - Services G:/Q:/Z:Lines
-* 
+*
 */
 
 
@@ -804,14 +804,14 @@ void sxline_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 		endIdx = (startIdx + 5);
 
 	if (IS_NULL(request)) {
-
-		send_notice_to_user(sourceNick, callerUser, "DUMP: \2S%c:Line\2 List (showing entries %d-%d):", str_char_toupper(request[1]), startIdx, endIdx);
-		LOG_DEBUG_SNOOP("Command: DUMP S%cLINE %d-%d -- by %s (%s@%s)", str_char_toupper(request[1]), startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
+		/* FIXME: str_char_toupper should return a signed int, not an unsigned one! */
+		send_notice_to_user(sourceNick, callerUser, "DUMP: \2S%c:Line\2 List (showing entries %d-%d):", (int)str_char_toupper(request[1]), startIdx, endIdx);
+		LOG_DEBUG_SNOOP("Command: DUMP S%cLINE %d-%d -- by %s (%s@%s)", (int)str_char_toupper(request[1]), startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host);
 	}
 	else {
-
-		send_notice_to_user(sourceNick, callerUser, "DUMP: \2S%c:Line\2 List (showing entries %d-%d matching %s):", str_char_toupper(request[1]), startIdx, endIdx, request);
-		LOG_DEBUG_SNOOP("Command: DUMP S%cLINE %d-%d -- by %s (%s@%s) [Pattern: %s]", str_char_toupper(request[1]), startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host, request);
+		/* FIXME: str_char_toupper should return a signed int, not an unsigned one! */
+		send_notice_to_user(sourceNick, callerUser, "DUMP: \2S%c:Line\2 List (showing entries %d-%d matching %s):", (int)str_char_toupper(request[1]), startIdx, endIdx, request);
+		LOG_DEBUG_SNOOP("Command: DUMP S%cLINE %d-%d -- by %s (%s@%s) [Pattern: %s]", (int)str_char_toupper(request[1]), startIdx, endIdx, callerUser->nick, callerUser->username, callerUser->host, request);
 	}
 
 	while (IS_NOT_NULL(aSXLine)) {

--- a/src/sxline.c
+++ b/src/sxline.c
@@ -771,7 +771,7 @@ void sxline_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 	if (IS_NULL(aSXLine)) {
 
-		send_notice_to_user(sourceNick, callerUser, "DUMP: \2S%c:Line\2 List is empty.", str_char_toupper(request[1]));
+		send_notice_to_user(sourceNick, callerUser, "DUMP: \2S%c:Line\2 List is empty.", (int)str_char_toupper(request[1]));
 		return;
 	}
 
@@ -833,13 +833,13 @@ void sxline_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",		lineIdx, (unsigned long)aSXLine, sizeof(SXLine));
-		send_notice_to_user(sourceNick, callerUser, "Name: 0x%08X \2[\2%s\2]\2",			(unsigned long)aSXLine->name, str_get_valid_display_value(aSXLine->name));
-		send_notice_to_user(sourceNick, callerUser, "Creator: 0x%08X \2[\2%s\2]\2",			(unsigned long)aSXLine->info.creator.name, str_get_valid_display_value(aSXLine->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Reason: 0x%08X \2[\2%s\2]\2",			(unsigned long)aSXLine->info.reason, str_get_valid_display_value(aSXLine->info.reason));
-		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %d",					aSXLine->info.creator.time);
-		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %d",					aSXLine->lastUsed);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: 0x%08X / 0x%08X",	(unsigned long)aSXLine->next, (unsigned long)aSXLine->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	lineIdx, aSXLine, sizeof(SXLine));
+		send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",		aSXLine->name, str_get_valid_display_value(aSXLine->name));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		aSXLine->info.creator.name, str_get_valid_display_value(aSXLine->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		aSXLine->info.reason, str_get_valid_display_value(aSXLine->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			aSXLine->info.creator.time);
+		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		aSXLine->lastUsed);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	aSXLine->next, aSXLine->prev);
 
 		if (sentIdx >= endIdx)
 			break;
@@ -875,7 +875,7 @@ unsigned long int sxline_mem_report(CSTR sourceNick, const User *callerUser) {
 		aSXLine = aSXLine->next;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "SQLine List: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "SQLine List: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	total_mem += mem;
 
 
@@ -896,7 +896,7 @@ unsigned long int sxline_mem_report(CSTR sourceNick, const User *callerUser) {
 		aSXLine = aSXLine->next;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "SGLine List: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "SGLine List: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	total_mem += mem;
 
 	return total_mem;

--- a/src/sxline.c
+++ b/src/sxline.c
@@ -833,13 +833,13 @@ void sxline_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	lineIdx, aSXLine, sizeof(SXLine));
-		send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",		aSXLine->name, str_get_valid_display_value(aSXLine->name));
-		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		aSXLine->info.creator.name, str_get_valid_display_value(aSXLine->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		aSXLine->info.reason, str_get_valid_display_value(aSXLine->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	lineIdx, (void *)aSXLine, sizeof(SXLine));
+		send_notice_to_user(sourceNick, callerUser, "Name: %p \2[\2%s\2]\2",		(void *)aSXLine->name, str_get_valid_display_value(aSXLine->name));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		(void *)aSXLine->info.creator.name, str_get_valid_display_value(aSXLine->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)aSXLine->info.reason, str_get_valid_display_value(aSXLine->info.reason));
 		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			aSXLine->info.creator.time);
 		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		aSXLine->lastUsed);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	aSXLine->next, aSXLine->prev);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	(void *)aSXLine->next, (void *)aSXLine->prev);
 
 		if (sentIdx >= endIdx)
 			break;

--- a/src/tagline.c
+++ b/src/tagline.c
@@ -522,7 +522,7 @@ void tagline_show(const time_t now) {
 
 	if (!CONF_SHOW_TAGLINES || IS_NULL(TaglineList)) {
 
-		send_globops(NULL, "Completed database write (%d secs)", time(NULL) - now);
+		send_globops(NULL, "Completed database write (%ld secs)", time(NULL) - now);
 		return;
 	}
 
@@ -540,12 +540,12 @@ void tagline_show(const time_t now) {
 			log_error(FACILITY_TAGLINE_SHOW, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_HALTED,
 				"tagline_show() returned NULL value (tagIdx: %d)", tagIdx);
 
-			send_globops(NULL, "Completed database write (%d secs)", time(NULL) - now);
+			send_globops(NULL, "Completed database write (%ld secs)", time(NULL) - now);
 			return;
 		}
 	}
 
-	send_globops(NULL, "Completed database write (%d secs) -> %s", (time(NULL) - now), aTagline->text);
+	send_globops(NULL, "Completed database write (%ld secs) -> %s", (time(NULL) - now), aTagline->text);
 }
 
 

--- a/src/tagline.c
+++ b/src/tagline.c
@@ -329,7 +329,7 @@ void handle_tagline(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(text)) > 260) {
 
-			send_notice_to_user(s_OperServ, callerUser, "The maximum length for a tagline is 260 characters. Your tagline has %d.", len);
+			send_notice_to_user(s_OperServ, callerUser, "The maximum length for a tagline is 260 characters. Your tagline has %lu.", len);
 			return;
 		}
 
@@ -623,11 +623,11 @@ void tagline_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",		taglineIdx, (unsigned long)aTagline, sizeof(Tagline));
-		send_notice_to_user(sourceNick, callerUser, "Text: 0x%08X \2[\2%s\2]\2",			(unsigned long)aTagline->text, str_get_valid_display_value(aTagline->text));
-		send_notice_to_user(sourceNick, callerUser, "Creator: 0x%08X \2[\2%s\2]\2",			(unsigned long)aTagline->creator.name, str_get_valid_display_value(aTagline->creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %d",					aTagline->creator.time);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: 0x%08X / 0x%08X",	(unsigned long)aTagline->next, (unsigned long)aTagline->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	taglineIdx, aTagline, sizeof(Tagline));
+		send_notice_to_user(sourceNick, callerUser, "Text: %p \2[\2%s\2]\2",		aTagline->text, str_get_valid_display_value(aTagline->text));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		aTagline->creator.name, str_get_valid_display_value(aTagline->creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			aTagline->creator.time);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	aTagline->next, aTagline->prev);
 
 		if (sentIdx >= endIdx)
 			break;
@@ -661,6 +661,6 @@ unsigned long int tagline_mem_report(CSTR sourceNick, const User *callerUser) {
 		aTagline = aTagline->next;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Tagline List: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Tagline List: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	return mem;
 }

--- a/src/tagline.c
+++ b/src/tagline.c
@@ -623,11 +623,11 @@ void tagline_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	taglineIdx, aTagline, sizeof(Tagline));
-		send_notice_to_user(sourceNick, callerUser, "Text: %p \2[\2%s\2]\2",		aTagline->text, str_get_valid_display_value(aTagline->text));
-		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		aTagline->creator.name, str_get_valid_display_value(aTagline->creator.name));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",	taglineIdx, (void *)aTagline, sizeof(Tagline));
+		send_notice_to_user(sourceNick, callerUser, "Text: %p \2[\2%s\2]\2",		(void *)aTagline->text, str_get_valid_display_value(aTagline->text));
+		send_notice_to_user(sourceNick, callerUser, "Creator: %p \2[\2%s\2]\2",		(void *)aTagline->creator.name, str_get_valid_display_value(aTagline->creator.name));
 		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			aTagline->creator.time);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	aTagline->next, aTagline->prev);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	(void *)aTagline->next, (void *)aTagline->prev);
 
 		if (sentIdx >= endIdx)
 			break;

--- a/src/tagline.c
+++ b/src/tagline.c
@@ -329,7 +329,7 @@ void handle_tagline(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		if ((len = str_len(text)) > 260) {
 
-			send_notice_to_user(s_OperServ, callerUser, "The maximum length for a tagline is 260 characters. Your tagline has %lu.", len);
+			send_notice_to_user(s_OperServ, callerUser, "The maximum length for a tagline is 260 characters. Your tagline has %zu.", len);
 			return;
 		}
 

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -321,7 +321,7 @@ void time_check(const time_t now) {
 
 		// midnight checks
 
-		send_globops(NULL, "Running Daily Database Expire %d", daily_dbcnt);
+		send_globops(NULL, "Running Daily Database Expire %lu", daily_dbcnt);
 		nickserv_daily_expire();
 		chanserv_daily_expire();
 		statserv_daily_expire();

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -87,8 +87,8 @@ BOOL timeout_add(TimeoutType type, int user_type, unsigned long hash, int interv
 
 	} else {
 
-		log_error(FACILITY_TIMEOUT_ADD_TIMEOUT, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_HALTED, 
-			"timeout_add(%u, %d, %lu, %d, %d, %p, %p) - Invalid parameters!", type, user_type, hash, interval, repeat, handler, data);
+		log_error(FACILITY_TIMEOUT_ADD_TIMEOUT, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_HALTED,
+			"timeout_add(%u, %d, %lu, %d, %d, %s, %p) - Invalid parameters!", type, user_type, hash, interval, repeat, IS_NULL(handler) ? "NULL" : "<function pointer>", data);
 		
 		return FALSE;
 	}

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -88,7 +88,7 @@ BOOL timeout_add(TimeoutType type, int user_type, unsigned long hash, int interv
 	} else {
 
 		log_error(FACILITY_TIMEOUT_ADD_TIMEOUT, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_HALTED, 
-			"timeout_add(%d, %d, %d, %d, %d, %08X, %08X) - Invalid parameters!", type, user_type, hash, interval, repeat, handler, data);
+			"timeout_add(%u, %d, %lu, %d, %d, %p, %p) - Invalid parameters!", type, user_type, hash, interval, repeat, handler, data);
 		
 		return FALSE;
 	}
@@ -195,7 +195,7 @@ BOOL timeout_remove(TimeoutType type, int user_type, unsigned long hash) {
 	}
 	else
 		log_error(FACILITY_TIMEOUT_DEL_TIMEOUT, __LINE__, LOG_TYPE_ERROR_ASSERTION, LOG_SEVERITY_ERROR_HALTED, 
-			"timeout_remove(%d, %d, %d) - Invalid parameters!", type, user_type, hash);
+			"timeout_remove(%u, %d, %lu) - Invalid parameters!", type, user_type, hash);
 
 	return TRUE;
 }

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -394,12 +394,12 @@ void timeout_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 							NickInfo *ni = ntd->ni;
 
-							send_notice_to_user(sourceNick, callerUser, "%d) \2%s\2 [Hash: %ld], Type: NickServ [%s], Created: %d seconds ago", count, ni ? ni->nick : "NULL", to->hash, to->user_type == TOTYPE_NICKSERV_COUNTDOWN ? "Countdown" : to->user_type == TOTYPE_NICKSERV_RELEASE ? "Release" : "Unknown", NOW - to->ts_creation);
+							send_notice_to_user(sourceNick, callerUser, "%d) \2%s\2 [Hash: %lu], Type: NickServ [%s], Created: %ld seconds ago", count, ni ? ni->nick : "NULL", to->hash, to->user_type == TOTYPE_NICKSERV_COUNTDOWN ? "Countdown" : to->user_type == TOTYPE_NICKSERV_RELEASE ? "Release" : "Unknown", NOW - to->ts_creation);
 							send_notice_to_user(sourceNick, callerUser, "Duration: %ds, Repeat: %s, Step: %d, User Online: %s", to->interval, to->repeat ? "Yes" : "No", ntd->step, ntd->user_online ? "Yes" : "No");
 						}
 						else {
 
-							send_notice_to_user(sourceNick, callerUser, "%d) NULL [Hash: %ld], Type: NickServ [%s], Created: %d seconds ago", count, to->hash, to->user_type == TOTYPE_NICKSERV_COUNTDOWN ? "Countdown" : to->user_type == TOTYPE_NICKSERV_RELEASE ? "Release" : "Unknown", NOW - to->ts_creation);
+							send_notice_to_user(sourceNick, callerUser, "%d) NULL [Hash: %lu], Type: NickServ [%s], Created: %ld seconds ago", count, to->hash, to->user_type == TOTYPE_NICKSERV_COUNTDOWN ? "Countdown" : to->user_type == TOTYPE_NICKSERV_RELEASE ? "Release" : "Unknown", NOW - to->ts_creation);
 							send_notice_to_user(sourceNick, callerUser, "Duration: %ds, Repeat: %s, Step: Unknown, User Online: Unknown [Note: to->data is NULL]", to->interval, to->repeat ? "Yes" : "No");
 						}
 						break;
@@ -417,31 +417,31 @@ void timeout_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 
 									ChannelInfo *ci = ctd->info.record;
 
-									send_notice_to_user(sourceNick, callerUser, "%d) \2%s\2 [Hash: %ld], Type: ChanServ [%s], Created: %d seconds ago", count, ci ? ci->name : "NULL", to->hash, to->user_type == TOTYPE_CHANSERV_UNBAN ? "Unban" : to->user_type == TOTYPE_CHANSERV_LEAVE ? "Leave" : "Unknown", NOW - to->ts_creation);
+									send_notice_to_user(sourceNick, callerUser, "%d) \2%s\2 [Hash: %lu], Type: ChanServ [%s], Created: %ld seconds ago", count, ci ? ci->name : "NULL", to->hash, to->user_type == TOTYPE_CHANSERV_UNBAN ? "Unban" : to->user_type == TOTYPE_CHANSERV_LEAVE ? "Leave" : "Unknown", NOW - to->ts_creation);
 									send_notice_to_user(sourceNick, callerUser, "Duration: %ds, Repeat: %s", to->interval, to->repeat ? "Yes" : "No");
 									break;
 								}
 								case CTOD_CHAN_NAME:
 
-									send_notice_to_user(sourceNick, callerUser, "%d) \2%s\2 [Hash: %ld], Type: ChanServ [%s], Created: %d seconds ago", count, ctd->info.name ? ctd->info.name : "NULL", to->hash, to->user_type == TOTYPE_CHANSERV_UNBAN ? "Unban" : to->user_type == TOTYPE_CHANSERV_LEAVE ? "Leave" : "Unknown", NOW - to->ts_creation);
+									send_notice_to_user(sourceNick, callerUser, "%d) \2%s\2 [Hash: %lu], Type: ChanServ [%s], Created: %ld seconds ago", count, ctd->info.name ? ctd->info.name : "NULL", to->hash, to->user_type == TOTYPE_CHANSERV_UNBAN ? "Unban" : to->user_type == TOTYPE_CHANSERV_LEAVE ? "Leave" : "Unknown", NOW - to->ts_creation);
 									send_notice_to_user(sourceNick, callerUser, "Duration: %ds, Repeat: %s", to->interval, to->repeat ? "Yes" : "No");
 									break;
 
 								default:
-									send_notice_to_user(sourceNick, callerUser, "%d) \2Unknown\2 [Hash: %ld], Type: ChanServ [%s], Created: %d seconds ago", count, to->hash, to->user_type == TOTYPE_CHANSERV_UNBAN ? "Unban" : to->user_type == TOTYPE_CHANSERV_LEAVE ? "Leave" : "Unknown", NOW - to->ts_creation);
+									send_notice_to_user(sourceNick, callerUser, "%d) \2Unknown\2 [Hash: %lu], Type: ChanServ [%s], Created: %ld seconds ago", count, to->hash, to->user_type == TOTYPE_CHANSERV_UNBAN ? "Unban" : to->user_type == TOTYPE_CHANSERV_LEAVE ? "Leave" : "Unknown", NOW - to->ts_creation);
 									send_notice_to_user(sourceNick, callerUser, "Duration: %ds, Repeat: %s", to->interval, to->repeat ? "Yes" : "No");
 									break;
 							}
 						}
 						else {
 
-							send_notice_to_user(sourceNick, callerUser, "%d) NULL [Hash: %ld], Type: ChanServ [%s], Created: %d seconds ago", count, to->hash, to->user_type == TOTYPE_CHANSERV_UNBAN ? "Unban" : to->user_type == TOTYPE_CHANSERV_LEAVE ? "Leave" : "Unknown", NOW - to->ts_creation);
+							send_notice_to_user(sourceNick, callerUser, "%d) NULL [Hash: %lu], Type: ChanServ [%s], Created: %ld seconds ago", count, to->hash, to->user_type == TOTYPE_CHANSERV_UNBAN ? "Unban" : to->user_type == TOTYPE_CHANSERV_LEAVE ? "Leave" : "Unknown", NOW - to->ts_creation);
 							send_notice_to_user(sourceNick, callerUser, "Duration: %ds, Repeat: %s [Note: to->data is NULL]", to->interval, to->repeat ? "Yes" : "No");
 						}
 						break;
 					}
 					default:
-						send_notice_to_user(sourceNick, callerUser, "%d) NULL [Hash: %ld], Type: Unknown, Created: %d seconds ago", count, to->hash, NOW - to->ts_creation);
+						send_notice_to_user(sourceNick, callerUser, "%d) NULL [Hash: %lu], Type: Unknown, Created: %ld seconds ago", count, to->hash, NOW - to->ts_creation);
 						send_notice_to_user(sourceNick, callerUser, "Duration: %ds, Repeat: %s", to->interval, to->repeat ? "Yes" : "No");
 						break;
 				}
@@ -460,7 +460,7 @@ void timeout_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			timebuf[sizeof(timebuf)-1] = '\0';
 
 			send_notice_to_user(sourceNick, callerUser, "Today values: day: \2%d\2, month: \2%d\2, year: \2%d\2, week day: \2%d\2", time_today_day, time_today_month, time_today_year, time_today_wday);
-			send_notice_to_user(sourceNick, callerUser, "Next midnight TS: \2%d\2 -> \2%s\2", time_next_midnight, timebuf);
+			send_notice_to_user(sourceNick, callerUser, "Next midnight TS: \2%ld\2 -> \2%s\2", time_next_midnight, timebuf);
 
 			LOG_DEBUG_SNOOP("Command: DUMP TIMEOUT TIME -- by %s (%s@%s)", callerUser->nick, callerUser->username, callerUser->host);
 

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -1140,7 +1140,7 @@ void handle_trigger(CSTR source, User *callerUser, ServiceCommandData *data) {
 			/* The requested mask is not already triggered. */
 			if (isADD == FALSE) {
 
-				send_notice_to_user(s_OperServ, callerUser, "Mask \2%s\2 is not triggered.", mask, tval);
+				send_notice_to_user(s_OperServ, callerUser, "Mask \2%s\2 is not triggered.", mask);
 
 				if (data->operMatch)
 					LOG_SNOOP(s_OperServ, "OS -T* %s -- by %s (%s@%s) [Not Found]", mask, callerUser->nick, callerUser->username, callerUser->host);
@@ -1320,17 +1320,17 @@ void trigger_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address 0x%08X, size %d B",		triggerIdx, (unsigned long)aTrigger, sizeof(Trigger));
-		send_notice_to_user(sourceNick, callerUser, "Username: 0x%08X \2[\2%s\2]\2",		(unsigned long)aTrigger->username, str_get_valid_display_value(aTrigger->username));
-		send_notice_to_user(sourceNick, callerUser, "Host: 0x%08X \2[\2%s\2]\2",			(unsigned long)aTrigger->host, str_get_valid_display_value(aTrigger->host));
-		send_notice_to_user(sourceNick, callerUser, "Reason: 0x%08X \2[\2%s\2]\2",			(unsigned long)aTrigger->info.reason, str_get_valid_display_value(aTrigger->info.reason));
-		send_notice_to_user(sourceNick, callerUser, "Set by: 0x%08X \2[\2%s\2]\2",			(unsigned long)aTrigger->info.creator.name, str_get_valid_display_value(aTrigger->info.creator.name));
-		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",					aTrigger->info.creator.time);
-		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",				aTrigger->lastUsed);
-		send_notice_to_user(sourceNick, callerUser, "Expire C-time: %ld",					aTrigger->expireTime);
-		send_notice_to_user(sourceNick, callerUser, "Flags: %d",							aTrigger->flags);
-		send_notice_to_user(sourceNick, callerUser, "Value: %d",							aTrigger->value);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: 0x%08X / 0x%08X",	(unsigned long)aTrigger->next, (unsigned long)aTrigger->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	triggerIdx, aTrigger, sizeof(Trigger));
+		send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",	aTrigger->username, str_get_valid_display_value(aTrigger->username));
+		send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		aTrigger->host, str_get_valid_display_value(aTrigger->host));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		aTrigger->info.reason, str_get_valid_display_value(aTrigger->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		aTrigger->info.creator.name, str_get_valid_display_value(aTrigger->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			aTrigger->info.creator.time);
+		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		aTrigger->lastUsed);
+		send_notice_to_user(sourceNick, callerUser, "Expire C-time: %ld",			aTrigger->expireTime);
+		send_notice_to_user(sourceNick, callerUser, "Flags: %d",					aTrigger->flags);
+		send_notice_to_user(sourceNick, callerUser, "Value: %u",					aTrigger->value);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	aTrigger->next, aTrigger->prev);
 
 		if (sentIdx >= endIdx)
 			break;
@@ -1369,7 +1369,7 @@ unsigned long int trigger_mem_report(CSTR sourceNick, const User *callerUser) {
 		aTrigger = aTrigger->next;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Trigger List: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Trigger List: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	total_mem += mem;
 
 	/* Exempt List */
@@ -1389,7 +1389,7 @@ unsigned long int trigger_mem_report(CSTR sourceNick, const User *callerUser) {
 		anExempt = anExempt->next;
 	}
 
-	send_notice_to_user(sourceNick, callerUser, "Exempt List: \2%d\2 -> \2%d\2 KB (\2%d\2 B)", count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Exempt List: \2%lu\2 -> \2%lu\2 KB (\2%lu\2 B)", count, mem / 1024, mem);
 	total_mem += mem;
 
 	return total_mem;

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -53,21 +53,21 @@ static void remove_trigger(Trigger *aTrigger, const User *callerUser, BOOL operM
 
 	if (operMatch) {
 
-		send_globops(s_OperServ, "\2%s\2 reset Trigger for \2%s@%s\2", callerUser->nick, aTrigger->username ?: "*", aTrigger->host);
+		send_globops(s_OperServ, "\2%s\2 reset Trigger for \2%s@%s\2", callerUser->nick, aTrigger->username ? aTrigger->username : "*", aTrigger->host);
 
-		LOG_SNOOP(s_OperServ, "OS -T %s@%s -- by %s (%s@%s)", aTrigger->username ?: "*", aTrigger->host, callerUser->nick, callerUser->username, callerUser->host);
-		log_services(LOG_SERVICES_OPERSERV, "-T %s@%s -- by %s (%s@%s)", aTrigger->username ?: "*", aTrigger->host, callerUser->nick, callerUser->username, callerUser->host);
+		LOG_SNOOP(s_OperServ, "OS -T %s@%s -- by %s (%s@%s)", aTrigger->username ? aTrigger->username : "*", aTrigger->host, callerUser->nick, callerUser->username, callerUser->host);
+		log_services(LOG_SERVICES_OPERSERV, "-T %s@%s -- by %s (%s@%s)", aTrigger->username ? aTrigger->username : "*", aTrigger->host, callerUser->nick, callerUser->username, callerUser->host);
 	}
 	else {
 
-		send_globops(s_OperServ, "\2%s\2 (through \2%s\2) reset Trigger for \2%s@%s\2", callerUser->nick, operName, aTrigger->username ?: "*", aTrigger->host);
+		send_globops(s_OperServ, "\2%s\2 (through \2%s\2) reset Trigger for \2%s@%s\2", callerUser->nick, operName, aTrigger->username ? aTrigger->username : "*", aTrigger->host);
 
-		LOG_SNOOP(s_OperServ, "OS -T %s@%s -- by %s (%s@%s) through %s", aTrigger->username ?: "*", aTrigger->host, callerUser->nick, callerUser->username, callerUser->host, operName);
-		log_services(LOG_SERVICES_OPERSERV, "-T %s@%s -- by %s (%s@%s) through %s", aTrigger->username ?: "*", aTrigger->host, callerUser->nick, callerUser->username, callerUser->host, operName);
+		LOG_SNOOP(s_OperServ, "OS -T %s@%s -- by %s (%s@%s) through %s", aTrigger->username ? aTrigger->username : "*", aTrigger->host, callerUser->nick, callerUser->username, callerUser->host, operName);
+		log_services(LOG_SERVICES_OPERSERV, "-T %s@%s -- by %s (%s@%s) through %s", aTrigger->username ? aTrigger->username : "*", aTrigger->host, callerUser->nick, callerUser->username, callerUser->host, operName);
 	}
 
 	TRACE_MAIN();
-	send_notice_to_user(s_OperServ, callerUser, "Trigger for \2%s@%s\2 has been reset.", aTrigger->username ?: "*", aTrigger->host);
+	send_notice_to_user(s_OperServ, callerUser, "Trigger for \2%s@%s\2 has been reset.", aTrigger->username ? aTrigger->username : "*", aTrigger->host);
 
 	/* Link around it. */
 	if (IS_NOT_NULL(aTrigger->next))
@@ -915,7 +915,7 @@ void handle_trigger(CSTR source, User *callerUser, ServiceCommandData *data) {
 					((ip == INADDR_NONE) && str_match_wild_nocase(aTrigger->host, host)) :
 					((ip != INADDR_NONE) && cidr_match(&(aTrigger->cidr), ip))) {
 
-					send_notice_to_user(s_OperServ, callerUser, "Mask \2%s@%s\2 is covered by trigger on \2%s@%s\2 [%s]", username, host, aTrigger->username ?: "*", aTrigger->host, FlagSet(aTrigger->flags, TRIGGER_FLAG_HOST) ? "Host" : "CIDR");
+					send_notice_to_user(s_OperServ, callerUser, "Mask \2%s@%s\2 is covered by trigger on \2%s@%s\2 [%s]", username, host, aTrigger->username ? aTrigger->username : "*", aTrigger->host, FlagSet(aTrigger->flags, TRIGGER_FLAG_HOST) ? "Host" : "CIDR");
 					return;
 				}
 			}
@@ -1320,17 +1320,17 @@ void trigger_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 			continue;
 		}
 
-		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %lu B",	triggerIdx, aTrigger, sizeof(Trigger));
-		send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",	aTrigger->username, str_get_valid_display_value(aTrigger->username));
-		send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		aTrigger->host, str_get_valid_display_value(aTrigger->host));
-		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		aTrigger->info.reason, str_get_valid_display_value(aTrigger->info.reason));
-		send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		aTrigger->info.creator.name, str_get_valid_display_value(aTrigger->info.creator.name));
+		send_notice_to_user(sourceNick, callerUser, "%d) Address %p, size %zu B",	triggerIdx, (void *)aTrigger, sizeof(Trigger));
+		send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",	(void *)aTrigger->username, str_get_valid_display_value(aTrigger->username));
+		send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",		(void *)aTrigger->host, str_get_valid_display_value(aTrigger->host));
+		send_notice_to_user(sourceNick, callerUser, "Reason: %p \2[\2%s\2]\2",		(void *)aTrigger->info.reason, str_get_valid_display_value(aTrigger->info.reason));
+		send_notice_to_user(sourceNick, callerUser, "Set by: %p \2[\2%s\2]\2",		(void *)aTrigger->info.creator.name, str_get_valid_display_value(aTrigger->info.creator.name));
 		send_notice_to_user(sourceNick, callerUser, "Time Set C-time: %ld",			aTrigger->info.creator.time);
 		send_notice_to_user(sourceNick, callerUser, "Last Used C-time: %ld",		aTrigger->lastUsed);
 		send_notice_to_user(sourceNick, callerUser, "Expire C-time: %ld",			aTrigger->expireTime);
 		send_notice_to_user(sourceNick, callerUser, "Flags: %d",					aTrigger->flags);
 		send_notice_to_user(sourceNick, callerUser, "Value: %u",					aTrigger->value);
-		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	aTrigger->next, aTrigger->prev);
+		send_notice_to_user(sourceNick, callerUser, "Next/Prev records: %p / %p",	(void *)aTrigger->next, (void *)aTrigger->prev);
 
 		if (sentIdx >= endIdx)
 			break;

--- a/src/users.c
+++ b/src/users.c
@@ -472,7 +472,7 @@ static User *user_create_user(CSTR nick, BOOL myClient) {
 	if (!myClient) {
 
 		if (IS_NOT_NULL(dynConf.welcomeNotice) && (synched == TRUE))
-			send_notice_to_user(s_GlobalNoticer, user, dynConf.welcomeNotice);
+			send_notice_to_user(s_GlobalNoticer, user, "%s", dynConf.welcomeNotice);
 	}
 
 	user->current_lang = LANG_DEFAULT;
@@ -3737,12 +3737,12 @@ void handle_uinfo(CSTR source, User *callerUser, ServiceCommandData *data) {
 
 		send_notice_to_user(data->agent->nick, callerUser, "\2Language\2: %s (%s)", lang_get_name(user->current_lang, TRUE), lang_get_name(user->current_lang, FALSE));
 
-		send_notice_to_user(data->agent->nick, callerUser, "\2Flood status\2: Level %d / Message count %d / Resets in %d seconds", user->flood_current_level, user->flood_msg_count, (user->flood_reset_time > NOW) ? (user->flood_reset_time - NOW) : 0);
-		send_notice_to_user(data->agent->nick, callerUser, "\2Invalid password status\2: Level %d / Count %d / Resets in %d seconds", user->invalid_pw_current_level, user->invalid_pw_count, (user->invalid_pw_reset_time > NOW) ? (user->invalid_pw_reset_time - NOW) : 0);
+		send_notice_to_user(data->agent->nick, callerUser, "\2Flood status\2: Level %d / Message count %d / Resets in %ld seconds", user->flood_current_level, user->flood_msg_count, (user->flood_reset_time > NOW) ? (user->flood_reset_time - NOW) : 0);
+		send_notice_to_user(data->agent->nick, callerUser, "\2Invalid password status\2: Level %d / Count %d / Resets in %ld seconds", user->invalid_pw_current_level, user->invalid_pw_count, (user->invalid_pw_reset_time > NOW) ? (user->invalid_pw_reset_time - NOW) : 0);
 
 		send_notice_to_user(data->agent->nick, callerUser, "\2Current Server\2: %s", user->server->name);
 
-		send_notice_to_user(data->agent->nick, callerUser, "\2TS Info\2: %lu", user->tsinfo);
+		send_notice_to_user(data->agent->nick, callerUser, "\2TS Info\2: %ld", user->tsinfo);
 		send_notice_to_user(data->agent->nick, callerUser, "\2Online Time (Server pov)\2: %s", convert_time(buffer, sizeof(buffer), (NOW - user->signon), LANG_DEFAULT));
 		send_notice_to_user(data->agent->nick, callerUser, "\2Online Time (Services pov)\2: %s", convert_time(buffer, sizeof(buffer), (NOW - user->my_signon), LANG_DEFAULT));
 
@@ -3807,7 +3807,7 @@ unsigned long user_mem_report(CSTR sourceNick, const User *callerUser) {
 	TRACE();
 	mem_total = mem;
 
-	send_notice_to_user(sourceNick, callerUser, "Online users: \2%d\2 [%d] -> \2%d\2 KB (\2%d\2 B)", count, user_online_user_count, mem / 1024, mem);
+	send_notice_to_user(sourceNick, callerUser, "Online users: \2%lu\2 [%u] -> \2%lu\2 KB (\2%lu\2 B)", count, user_online_user_count, mem / 1024, mem);
 
 	return mem_total;
 }
@@ -3832,50 +3832,50 @@ static void user_ds_dump_display(CSTR sourceNick, const User *callerUser, const 
 	}
 
 	send_notice_to_user(sourceNick, callerUser, "DUMP: user \2%s\2", user->nick);
-	send_notice_to_user(sourceNick, callerUser, "Address 0x%08X, size %d B",				(unsigned long)user, sizeof(User) + str_len(user->username) + str_len(user->host) + str_len(user->maskedHost) + str_len(user->realname) + 4);
-	send_notice_to_user(sourceNick, callerUser, "Nick: %s",									user->nick);
-	send_notice_to_user(sourceNick, callerUser, "Username: 0x%08X \2[\2%s\2]\2",			(unsigned long)user->username, str_get_valid_display_value(user->username));
-	send_notice_to_user(sourceNick, callerUser, "Host: 0x%08X \2[\2%s\2]\2",				(unsigned long)user->host, str_get_valid_display_value(user->host));
+	send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",						user, sizeof(User) + str_len(user->username) + str_len(user->host) + str_len(user->maskedHost) + str_len(user->realname) + 4);
+	send_notice_to_user(sourceNick, callerUser, "Nick: %s",										user->nick);
+	send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",					user->username, str_get_valid_display_value(user->username));
+	send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",						user->host, str_get_valid_display_value(user->host));
 
 	#ifdef ENABLE_CAPAB_NICKIP
 	if (FlagUnset(user->flags, USER_FLAG_HAS_IPV6) || FlagSet(user->flags, USER_FLAG_6TO4 | USER_FLAG_TEREDO))
-		send_notice_to_user(sourceNick, callerUser, "IP from NICKIP: 0x%08X \2[\2%lu\2]\2",		user->ip, user->ip);
+		send_notice_to_user(sourceNick, callerUser, "IP from NICKIP: %#lx \2[\2%s\2]\2",		user->ip, get_ip(user->ip));
 	if (FlagSet(user->flags, USER_FLAG_HAS_IPV6))
-		send_notice_to_user(sourceNick, callerUser, "IPv6 from NICKIP: \002[\002%s\002]\002", get_ip6(user->ipv6));
+		send_notice_to_user(sourceNick, callerUser, "IPv6 from NICKIP: \002[\002%s\002]\002",	get_ip6(user->ipv6));
 	#endif
 
-	send_notice_to_user(sourceNick, callerUser, "Masked host: 0x%08X \2[\2%s\2]\2",			(unsigned long)user->maskedHost, str_get_valid_display_value(user->maskedHost));
-	send_notice_to_user(sourceNick, callerUser, "Realname: 0x%08X \2[\2%s\2]\2",			(unsigned long)user->realname, str_get_valid_display_value(user->realname));
-	send_notice_to_user(sourceNick, callerUser, "Server: 0x%08X \2[\2%s\2]\2",				(unsigned long)user->server, str_get_valid_display_value(user->server ? user->server->name : NULL));
-	send_notice_to_user(sourceNick, callerUser, "Username: 0x%08X \2[\2%s\2]\2",			(unsigned long)user->username, str_get_valid_display_value(user->username));
-	send_notice_to_user(sourceNick, callerUser, "TS Info: %lu",								user->tsinfo);
-	send_notice_to_user(sourceNick, callerUser, "Signon (Server POV): %lu",					user->signon);
-	send_notice_to_user(sourceNick, callerUser, "Signon (Services POV): %lu",				user->my_signon);
-	send_notice_to_user(sourceNick, callerUser, "Modes: 0x%08X (%s)",						(unsigned long)user->mode, get_user_modes(user->mode, 0));
-	send_notice_to_user(sourceNick, callerUser, "Flags: 0x%08X (%s)",						(unsigned long)user->flags, get_user_flags(user->flags));
+	send_notice_to_user(sourceNick, callerUser, "Masked host: %p \2[\2%s\2]\2",					user->maskedHost, str_get_valid_display_value(user->maskedHost));
+	send_notice_to_user(sourceNick, callerUser, "Realname: %p \2[\2%s\2]\2",					user->realname, str_get_valid_display_value(user->realname));
+	send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",						user->server, str_get_valid_display_value(user->server ? user->server->name : NULL));
+	send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",					user->username, str_get_valid_display_value(user->username));
+	send_notice_to_user(sourceNick, callerUser, "TS Info: %ld",									user->tsinfo);
+	send_notice_to_user(sourceNick, callerUser, "Signon (Server POV): %ld",						user->signon);
+	send_notice_to_user(sourceNick, callerUser, "Signon (Services POV): %ld",					user->my_signon);
+	send_notice_to_user(sourceNick, callerUser, "Modes: %#lx (%s)",								(unsigned long)user->mode, get_user_modes(user->mode, 0));
+	send_notice_to_user(sourceNick, callerUser, "Flags: %#lx (%s)",								(unsigned long)user->flags, get_user_flags(user->flags));
 
-	send_notice_to_user(sourceNick, callerUser, "Invalid password status: Level / Count / Reset C-time: %d / %d / %d", user->invalid_pw_current_level, user->invalid_pw_count, user->invalid_pw_reset_time);
-	send_notice_to_user(sourceNick, callerUser, "Last memo C-time: %d",						user->lastmemosend);
-	send_notice_to_user(sourceNick, callerUser, "Last nick registration C-time: %d",		user->lastnickreg);
-	send_notice_to_user(sourceNick, callerUser, "Flood status: Level / Message count / Reset C-time: %d / %d / %d", user->flood_current_level, user->flood_msg_count, user->flood_reset_time);
+	send_notice_to_user(sourceNick, callerUser, "Invalid password status: Level / Count / Reset C-time: %u / %u / %ld", user->invalid_pw_current_level, user->invalid_pw_count, user->invalid_pw_reset_time);
+	send_notice_to_user(sourceNick, callerUser, "Last memo C-time: %ld",						user->lastmemosend);
+	send_notice_to_user(sourceNick, callerUser, "Last nick registration C-time: %ld",			user->lastnickreg);
+	send_notice_to_user(sourceNick, callerUser, "Flood status: Level / Message count / Reset C-time: %u / %u / %ld", user->flood_current_level, user->flood_msg_count, user->flood_reset_time);
 
-	send_notice_to_user(sourceNick, callerUser, "NickInfo record: 0x%08X \2[\2%s\2]\2",		(unsigned long)user->ni, user->ni ? str_get_valid_display_value(user->ni->nick) : "NULL");
+	send_notice_to_user(sourceNick, callerUser, "NickInfo record: %p \2[\2%s\2]\2",				user->ni, user->ni ? str_get_valid_display_value(user->ni->nick) : "NULL");
 
-	send_notice_to_user(sourceNick, callerUser, "Next / previous record: 0x%08X / 0x%08X",	(unsigned long)user->next, (unsigned long)user->prev);
+	send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",				user->next, user->prev);
 
-	send_notice_to_user(sourceNick, callerUser, s_SPACE);
+	send_notice_to_user(sourceNick, callerUser, " ");
 	send_notice_to_user(sourceNick, callerUser, "\2Channel list\2 (name | next / previous record):");
 
 	for (item = user->chans, idx = 1; IS_NOT_NULL(item); ++idx, item = item->next)
-		send_notice_to_user(sourceNick, callerUser, "%d) %s | 0x%08X / 0x%08X", idx, IS_NOT_NULL(item->chan) ? item->chan->name : "NULL pointer", item->next, item->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) %s | %p / %p", idx, IS_NOT_NULL(item->chan) ? item->chan->name : "NULL pointer", item->next, item->prev);
 
-	send_notice_to_user(sourceNick, callerUser, s_SPACE);
+	send_notice_to_user(sourceNick, callerUser, " ");
 	send_notice_to_user(sourceNick, callerUser, "\2Identified-channel list\2 (name | next / previous record):");
 
 	for (infoItem = user->founder_chans, idx = 1; IS_NOT_NULL(infoItem); ++idx, infoItem = infoItem->next)
-		send_notice_to_user(sourceNick, callerUser, "%d) %s | 0x%08X / 0x%08X", idx, IS_NOT_NULL(infoItem->ci) ? infoItem->ci->name : "NULL pointer", infoItem->next, infoItem->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) %s | %p / %p", idx, IS_NOT_NULL(infoItem->ci) ? infoItem->ci->name : "NULL pointer", infoItem->next, infoItem->prev);
 
-	send_notice_to_user(sourceNick, callerUser, s_SPACE);
+	send_notice_to_user(sourceNick, callerUser, " ");
 	send_notice_to_user(sourceNick, callerUser, "\2Identified-nick list\2:");
 
 	for (idnicks = user->id_nicks, idx = 0; idx < user->idcount; ++idnicks, ++idx)
@@ -3999,7 +3999,7 @@ void user_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					HASH_FOREACH_BRANCH(idx, ONLINEHOST_HASHSIZE) {
 
 						host_item = hashtable_onlinehost[idx];
-						send_notice_to_user(sourceNick, callerUser, "%d) 0x%X", idx ,host_item);
+						send_notice_to_user(sourceNick, callerUser, "%ld) %p", idx, host_item);
 					}
 				}
 			}
@@ -4014,11 +4014,11 @@ void user_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 		MemoryPoolStats pstats;
 
 		mempool_stats(user_mempool, &pstats);
-		send_notice_to_user(sourceNick, callerUser, "DUMP: Users memory pool - Address 0x%08X, ID: %d",	(unsigned long)user_mempool, pstats.id);
-		send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %d B / %d B",				pstats.memory_allocated, pstats.memory_free);
-		send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %d / %d",					pstats.items_allocated, pstats.items_free);
-		send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %d / %d",			pstats.items_per_block, pstats.block_count);
-		//send_notice_to_user(sourceNick, callerUser, "Avarage use: %.2f%%",								pstats.block_avg_usage);
+		send_notice_to_user(sourceNick, callerUser, "DUMP: Users memory pool - Address %p, ID: %u",	user_mempool, pstats.id);
+		send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",		pstats.memory_allocated, pstats.memory_free);
+		send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",			pstats.items_allocated, pstats.items_free);
+		send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",		pstats.items_per_block, pstats.block_count);
+		//send_notice_to_user(sourceNick, callerUser, "Avarage use: %.2f%%",						pstats.block_avg_usage);
 	}
 	#endif
 

--- a/src/users.c
+++ b/src/users.c
@@ -285,7 +285,7 @@ static BOOL user_onlinehost_remove(const User *user) {
 			return TRUE;
 		}
 		else
-			LOG_DEBUG_SNOOP("user_onlinehost_remove() - !hash_onlinehost_find() user %s | item = 0x%0X | item->u = 0x%0X | user = 0x%0X", user->nick, item, item ? item->user : 0, user);
+			LOG_DEBUG_SNOOP("user_onlinehost_remove() - !hash_onlinehost_find() user %s | item = %p | item->u = %p | user = %p", user->nick, item, item ? item->user : 0, user);
 	}
 
 	return FALSE;
@@ -1660,7 +1660,7 @@ void user_handle_JOIN(CSTR source, const int ac, char **av) {
 			else
 				TimeStamp = NOW;
 
-			snprintf(channel_TS, sizeof(channel_TS), "%lu", TimeStamp);
+			snprintf(channel_TS, sizeof(channel_TS), "%ld", TimeStamp);
 
 			if (FlagSet(uplink_capab, CAPAB_SSJOIN)) {
 

--- a/src/users.c
+++ b/src/users.c
@@ -285,7 +285,7 @@ static BOOL user_onlinehost_remove(const User *user) {
 			return TRUE;
 		}
 		else
-			LOG_DEBUG_SNOOP("user_onlinehost_remove() - !hash_onlinehost_find() user %s | item = %p | item->u = %p | user = %p", user->nick, item, item ? item->user : 0, user);
+			LOG_DEBUG_SNOOP("user_onlinehost_remove() - !hash_onlinehost_find() user %s | item = %p | item->u = %p | user = %p", user->nick, (void *)item, (void *)(item ? item->user : NULL), (void *)user);
 	}
 
 	return FALSE;
@@ -3832,10 +3832,10 @@ static void user_ds_dump_display(CSTR sourceNick, const User *callerUser, const 
 	}
 
 	send_notice_to_user(sourceNick, callerUser, "DUMP: user \2%s\2", user->nick);
-	send_notice_to_user(sourceNick, callerUser, "Address %p, size %lu B",						user, sizeof(User) + str_len(user->username) + str_len(user->host) + str_len(user->maskedHost) + str_len(user->realname) + 4);
+	send_notice_to_user(sourceNick, callerUser, "Address %p, size %zu B",						(void *)user, sizeof(User) + str_len(user->username) + str_len(user->host) + str_len(user->maskedHost) + str_len(user->realname) + 4);
 	send_notice_to_user(sourceNick, callerUser, "Nick: %s",										user->nick);
-	send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",					user->username, str_get_valid_display_value(user->username));
-	send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",						user->host, str_get_valid_display_value(user->host));
+	send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",					(void *)user->username, str_get_valid_display_value(user->username));
+	send_notice_to_user(sourceNick, callerUser, "Host: %p \2[\2%s\2]\2",						(void *)user->host, str_get_valid_display_value(user->host));
 
 	#ifdef ENABLE_CAPAB_NICKIP
 	if (FlagUnset(user->flags, USER_FLAG_HAS_IPV6) || FlagSet(user->flags, USER_FLAG_6TO4 | USER_FLAG_TEREDO))
@@ -3844,10 +3844,10 @@ static void user_ds_dump_display(CSTR sourceNick, const User *callerUser, const 
 		send_notice_to_user(sourceNick, callerUser, "IPv6 from NICKIP: \002[\002%s\002]\002",	get_ip6(user->ipv6));
 	#endif
 
-	send_notice_to_user(sourceNick, callerUser, "Masked host: %p \2[\2%s\2]\2",					user->maskedHost, str_get_valid_display_value(user->maskedHost));
-	send_notice_to_user(sourceNick, callerUser, "Realname: %p \2[\2%s\2]\2",					user->realname, str_get_valid_display_value(user->realname));
-	send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",						user->server, str_get_valid_display_value(user->server ? user->server->name : NULL));
-	send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",					user->username, str_get_valid_display_value(user->username));
+	send_notice_to_user(sourceNick, callerUser, "Masked host: %p \2[\2%s\2]\2",					(void *)user->maskedHost, str_get_valid_display_value(user->maskedHost));
+	send_notice_to_user(sourceNick, callerUser, "Realname: %p \2[\2%s\2]\2",					(void *)user->realname, str_get_valid_display_value(user->realname));
+	send_notice_to_user(sourceNick, callerUser, "Server: %p \2[\2%s\2]\2",						(void *)user->server, str_get_valid_display_value(user->server ? user->server->name : NULL));
+	send_notice_to_user(sourceNick, callerUser, "Username: %p \2[\2%s\2]\2",					(void *)user->username, str_get_valid_display_value(user->username));
 	send_notice_to_user(sourceNick, callerUser, "TS Info: %ld",									user->tsinfo);
 	send_notice_to_user(sourceNick, callerUser, "Signon (Server POV): %ld",						user->signon);
 	send_notice_to_user(sourceNick, callerUser, "Signon (Services POV): %ld",					user->my_signon);
@@ -3859,21 +3859,21 @@ static void user_ds_dump_display(CSTR sourceNick, const User *callerUser, const 
 	send_notice_to_user(sourceNick, callerUser, "Last nick registration C-time: %ld",			user->lastnickreg);
 	send_notice_to_user(sourceNick, callerUser, "Flood status: Level / Message count / Reset C-time: %u / %u / %ld", user->flood_current_level, user->flood_msg_count, user->flood_reset_time);
 
-	send_notice_to_user(sourceNick, callerUser, "NickInfo record: %p \2[\2%s\2]\2",				user->ni, user->ni ? str_get_valid_display_value(user->ni->nick) : "NULL");
+	send_notice_to_user(sourceNick, callerUser, "NickInfo record: %p \2[\2%s\2]\2",				(void *)user->ni, user->ni ? str_get_valid_display_value(user->ni->nick) : "NULL");
 
-	send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",				user->next, user->prev);
+	send_notice_to_user(sourceNick, callerUser, "Next / previous record: %p / %p",				(void *)user->next, (void *)user->prev);
 
 	send_notice_to_user(sourceNick, callerUser, " ");
 	send_notice_to_user(sourceNick, callerUser, "\2Channel list\2 (name | next / previous record):");
 
 	for (item = user->chans, idx = 1; IS_NOT_NULL(item); ++idx, item = item->next)
-		send_notice_to_user(sourceNick, callerUser, "%d) %s | %p / %p", idx, IS_NOT_NULL(item->chan) ? item->chan->name : "NULL pointer", item->next, item->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) %s | %p / %p", idx, IS_NOT_NULL(item->chan) ? item->chan->name : "NULL pointer", (void *)item->next, (void *)item->prev);
 
 	send_notice_to_user(sourceNick, callerUser, " ");
 	send_notice_to_user(sourceNick, callerUser, "\2Identified-channel list\2 (name | next / previous record):");
 
 	for (infoItem = user->founder_chans, idx = 1; IS_NOT_NULL(infoItem); ++idx, infoItem = infoItem->next)
-		send_notice_to_user(sourceNick, callerUser, "%d) %s | %p / %p", idx, IS_NOT_NULL(infoItem->ci) ? infoItem->ci->name : "NULL pointer", infoItem->next, infoItem->prev);
+		send_notice_to_user(sourceNick, callerUser, "%d) %s | %p / %p", idx, IS_NOT_NULL(infoItem->ci) ? infoItem->ci->name : "NULL pointer", (void *)infoItem->next, (void *)infoItem->prev);
 
 	send_notice_to_user(sourceNick, callerUser, " ");
 	send_notice_to_user(sourceNick, callerUser, "\2Identified-nick list\2:");
@@ -3999,7 +3999,7 @@ void user_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 					HASH_FOREACH_BRANCH(idx, ONLINEHOST_HASHSIZE) {
 
 						host_item = hashtable_onlinehost[idx];
-						send_notice_to_user(sourceNick, callerUser, "%ld) %p", idx, host_item);
+						send_notice_to_user(sourceNick, callerUser, "%ld) %p", idx, (void *)host_item);
 					}
 				}
 			}
@@ -4014,7 +4014,7 @@ void user_ds_dump(CSTR sourceNick, const User *callerUser, STR request) {
 		MemoryPoolStats pstats;
 
 		mempool_stats(user_mempool, &pstats);
-		send_notice_to_user(sourceNick, callerUser, "DUMP: Users memory pool - Address %p, ID: %u",	user_mempool, pstats.id);
+		send_notice_to_user(sourceNick, callerUser, "DUMP: Users memory pool - Address %p, ID: %u",	(void *)user_mempool, pstats.id);
 		send_notice_to_user(sourceNick, callerUser, "Memory allocated / free: %lu B / %lu B",		pstats.memory_allocated, pstats.memory_free);
 		send_notice_to_user(sourceNick, callerUser, "Items allocated / free: %lu / %lu",			pstats.items_allocated, pstats.items_free);
 		send_notice_to_user(sourceNick, callerUser, "Items per block / block count: %lu / %lu",		pstats.items_per_block, pstats.block_count);


### PR DESCRIPTION
This is the "sister" PR of azzurra/bahamut#32, this time we'll try to clean up the varargs mess in the services.

This is going to be way more complex, though, because `-Wformat` and `-Werror=format` don't play nice with non-constant `char *` passed as format strings to printf-like functions, and we do that **for every localized message sent by services to users**.

Expect major CI breakages that will be solved by subsequent commits. Eventually. 